### PR TITLE
Add IsIPvX methods for IP

### DIFF
--- a/ips.go
+++ b/ips.go
@@ -10,6 +10,7 @@ type IPService struct {
 // IP represents an IP address
 type IP struct {
 	Address string `json:"ipaddress"`
+	Version int    `json:"version"`
 }
 
 // AvailableIPsParams is used to filter results when listing available IP addresses

--- a/ips.go
+++ b/ips.go
@@ -1,6 +1,10 @@
 package glesys
 
-import "context"
+import (
+	"context"
+	"net"
+	"strings"
+)
 
 // IPService provides functions to interact with IP addresses
 type IPService struct {
@@ -10,7 +14,6 @@ type IPService struct {
 // IP represents an IP address
 type IP struct {
 	Address string `json:"ipaddress"`
-	Version int    `json:"version"`
 }
 
 // AvailableIPsParams is used to filter results when listing available IP addresses
@@ -41,6 +44,18 @@ func (s *IPService) Available(context context.Context, params AvailableIPsParams
 		ips = append(ips, IP{Address: address})
 	}
 	return &ips, nil
+}
+
+// IsIPv4 verify that ip is IPv4
+func (ip *IP) IsIPv4() bool {
+	netAddr := net.ParseIP(ip.Address)
+	return netAddr != nil && strings.Contains(ip.Address, ".")
+}
+
+// IsIPv6 verify that ip is IPv6
+func (ip *IP) IsIPv6() bool {
+	netAddr := net.ParseIP(ip.Address)
+	return netAddr != nil && strings.Contains(ip.Address, ":")
 }
 
 // Release releases a reserved IP address

--- a/ips_test.go
+++ b/ips_test.go
@@ -18,9 +18,35 @@ func TestIPsAvailable(t *testing.T) {
 	assert.Equal(t, "127.0.0.1", (*ips)[0].Address, "one ip was returned")
 }
 
+func TestIPsIsIPv4(t *testing.T) {
+	var ips = []IP{
+		{Address: "127.0.0.1"},
+		{Address: "300.0.0.1"},
+		{Address: "2001:db8::1"},
+	}
+
+	assert.Equal(t, true, ips[0].IsIPv4(), "ip is version 4")
+	assert.Equal(t, false, ips[1].IsIPv4(), "ip is not version 4")
+	assert.Equal(t, false, ips[2].IsIPv4(), "ip is not version 4")
+}
+
+func TestIPsIsIPv6(t *testing.T) {
+	var ips = []IP{
+		{Address: "2001:db8::1"},
+		{Address: "::1"},
+		{Address: "300.0.0.1"},
+		{Address: "::2001::1"},
+	}
+
+	assert.Equal(t, true, ips[0].IsIPv6(), "ip is version 6")
+	assert.Equal(t, true, ips[1].IsIPv6(), "ip is version 6")
+	assert.Equal(t, false, ips[2].IsIPv6(), "ip is not version 6")
+	assert.Equal(t, false, ips[3].IsIPv6(), "ip is not version 6")
+}
+
 func TestIPsReserved(t *testing.T) {
-	c := &mockClient{body: `{ "response": { "iplist": [{ "ipaddress": "127.0.0.1", "version": 4 },
-		{ "ipaddress": "2001:db8::1", "version": 6 }] } }`}
+	c := &mockClient{body: `{ "response": { "iplist": [{ "ipaddress": "127.0.0.1"},
+		{ "ipaddress": "2001:db8::1"}] } }`}
 	s := IPService{client: c}
 
 	ips, _ := s.Reserved(context.Background())
@@ -28,9 +54,7 @@ func TestIPsReserved(t *testing.T) {
 	assert.Equal(t, "GET", c.lastMethod, "method used is correct")
 	assert.Equal(t, "ip/listown", c.lastPath, "path used is correct")
 	assert.Equal(t, "127.0.0.1", (*ips)[0].Address, "one ip was returned")
-	assert.Equal(t, 4, (*ips)[0].Version, "IPv4 address")
 	assert.Equal(t, "2001:db8::1", (*ips)[1].Address, "one ip was returned")
-	assert.Equal(t, 6, (*ips)[1].Version, "IPv6 address")
 }
 
 func TestIPsReserve(t *testing.T) {

--- a/ips_test.go
+++ b/ips_test.go
@@ -19,7 +19,8 @@ func TestIPsAvailable(t *testing.T) {
 }
 
 func TestIPsReserved(t *testing.T) {
-	c := &mockClient{body: `{ "response": { "iplist": [{ "ipaddress": "127.0.0.1" }] } }`}
+	c := &mockClient{body: `{ "response": { "iplist": [{ "ipaddress": "127.0.0.1", "version": 4 },
+		{ "ipaddress": "2001:db8::1", "version": 6 }] } }`}
 	s := IPService{client: c}
 
 	ips, _ := s.Reserved(context.Background())
@@ -27,6 +28,9 @@ func TestIPsReserved(t *testing.T) {
 	assert.Equal(t, "GET", c.lastMethod, "method used is correct")
 	assert.Equal(t, "ip/listown", c.lastPath, "path used is correct")
 	assert.Equal(t, "127.0.0.1", (*ips)[0].Address, "one ip was returned")
+	assert.Equal(t, 4, (*ips)[0].Version, "IPv4 address")
+	assert.Equal(t, "2001:db8::1", (*ips)[1].Address, "one ip was returned")
+	assert.Equal(t, 6, (*ips)[1].Version, "IPv6 address")
 }
 
 func TestIPsReserve(t *testing.T) {


### PR DESCRIPTION
Return the version variable along with the IP address, allows for easier
handling of IP addresses without having to do manual parsing.