### PR TITLE
Add support for handling networks

### DIFF
--- a/client.go
+++ b/client.go
@@ -30,8 +30,9 @@ type Client struct {
 	project    string
 	userAgent  string
 
-	IPs     *IPService
-	Servers *ServerService
+	IPs      *IPService
+	Servers  *ServerService
+	Networks *NetworkService
 }
 
 // NewClient creates a new Client for interacting with the GleSYS API. This is
@@ -49,6 +50,7 @@ func NewClient(project, apiKey, userAgent string) *Client {
 
 	c.IPs = &IPService{client: c}
 	c.Servers = &ServerService{client: c}
+	c.Networks = &NetworkService{client: c}
 
 	return c
 }

--- a/networks.go
+++ b/networks.go
@@ -8,15 +8,15 @@ type NetworkService struct {
 }
 
 // Network represents a network
-type NetworkDetails struct {
-	Datacenter  string `json:"datacenter"`
+type Network struct {
+	DataCenter  string `json:"datacenter"`
 	Description string `json:"description"`
 	ID          string `json:"networkid"`
 	Public      string `json:"public"`
 }
 
 type CreateNetworkParams struct {
-	Datacenter  string `json:"datacenter"`
+	DataCenter  string `json:"datacenter"`
 	Description string `json:"description"`
 }
 
@@ -25,10 +25,10 @@ type EditNetworkParams struct {
 }
 
 // Create creates a new network
-func (s *NetworkService) Create(context context.Context, params CreateNetworkParams) (*NetworkDetails, error) {
+func (s *NetworkService) Create(context context.Context, params CreateNetworkParams) (*Network, error) {
 	data := struct {
 		Response struct {
-			Network NetworkDetails
+			Network Network
 		}
 	}{}
 	err := s.client.post(context, "network/create", &data, params)
@@ -36,10 +36,10 @@ func (s *NetworkService) Create(context context.Context, params CreateNetworkPar
 }
 
 // Details returns detailed information about one network
-func (s *NetworkService) Details(context context.Context, networkID string) (*NetworkDetails, error) {
+func (s *NetworkService) Details(context context.Context, networkID string) (*Network, error) {
 	data := struct {
 		Response struct {
-			Network NetworkDetails
+			Network Network
 		}
 	}{}
 	err := s.client.post(context, "network/details", &data, struct {
@@ -56,10 +56,10 @@ func (s *NetworkService) Destroy(context context.Context, networkID string) erro
 }
 
 // Edit modifies a network
-func (s *NetworkService) Edit(context context.Context, networkID string, params EditNetworkParams) (*NetworkDetails, error) {
+func (s *NetworkService) Edit(context context.Context, networkID string, params EditNetworkParams) (*Network, error) {
 	data := struct {
 		Response struct {
-			Network NetworkDetails
+			Network Network
 		}
 	}{}
 	err := s.client.post(context, "network/edit", &data, struct {
@@ -70,10 +70,10 @@ func (s *NetworkService) Edit(context context.Context, networkID string, params 
 }
 
 // List returns a list of Networks available under your account
-func (s *NetworkService) List(context context.Context) (*[]NetworkDetails, error) {
+func (s *NetworkService) List(context context.Context) (*[]Network, error) {
 	data := struct {
 		Response struct {
-			Networks []NetworkDetails
+			Networks []Network
 		}
 	}{}
 

--- a/networks.go
+++ b/networks.go
@@ -1,0 +1,82 @@
+package glesys
+
+import "context"
+
+// NetworkService provides functions to interact with Networks
+type NetworkService struct {
+	client clientInterface
+}
+
+// Network represents a network
+type NetworkDetails struct {
+	Datacenter  string `json:"datacenter"`
+	Description string `json:"description"`
+	ID          string `json:"networkid"`
+	Public      string `json:"public"`
+}
+
+type CreateNetworkParams struct {
+	Datacenter  string `json:"datacenter"`
+	Description string `json:"description"`
+}
+
+type EditNetworkParams struct {
+	Description string `json:"description"`
+}
+
+// Create creates a new network
+func (s *NetworkService) Create(context context.Context, params CreateNetworkParams) (*NetworkDetails, error) {
+	data := struct {
+		Response struct {
+			Network NetworkDetails
+		}
+	}{}
+	err := s.client.post(context, "network/create", &data, params)
+	return &data.Response.Network, err
+}
+
+// Details returns detailed information about one network
+func (s *NetworkService) Details(context context.Context, networkID string) (*NetworkDetails, error) {
+	data := struct {
+		Response struct {
+			Network NetworkDetails
+		}
+	}{}
+	err := s.client.post(context, "network/details", &data, struct {
+		NetworkID string `json:"networkid"`
+	}{networkID})
+	return &data.Response.Network, err
+}
+
+// Destroy deletes a network
+func (s *NetworkService) Destroy(context context.Context, networkID string) error {
+	return s.client.post(context, "network/delete", nil, struct {
+		NetworkID string `json:"networkid"`
+	}{networkID})
+}
+
+// Edit modifies a network
+func (s *NetworkService) Edit(context context.Context, networkID string, params EditNetworkParams) (*NetworkDetails, error) {
+	data := struct {
+		Response struct {
+			Network NetworkDetails
+		}
+	}{}
+	err := s.client.post(context, "network/edit", &data, struct {
+		EditNetworkParams
+		NetworkID string `json:"networkid"`
+	}{params, networkID})
+	return &data.Response.Network, err
+}
+
+// List returns a list of Networks available under your account
+func (s *NetworkService) List(context context.Context) (*[]NetworkDetails, error) {
+	data := struct {
+		Response struct {
+			Networks []NetworkDetails
+		}
+	}{}
+
+	err := s.client.get(context, "network/list", &data)
+	return &data.Response.Networks, err
+}

--- a/networks_test.go
+++ b/networks_test.go
@@ -13,7 +13,7 @@ func TestNetworksCreate(t *testing.T) {
 	n := NetworkService{client: c}
 
 	params := CreateNetworkParams{
-		Datacenter:  "Falkenberg",
+		DataCenter:  "Falkenberg",
 		Description: "mynetwork",
 	}
 
@@ -22,7 +22,7 @@ func TestNetworksCreate(t *testing.T) {
 	assert.Equal(t, "POST", c.lastMethod, "method is used correct")
 	assert.Equal(t, "network/create", c.lastPath, "path used is correct")
 	assert.Equal(t, "vl123456", network.ID, "network ID is correct")
-	assert.Equal(t, "Falkenberg", network.Datacenter, "network Datacenter is correct")
+	assert.Equal(t, "Falkenberg", network.DataCenter, "network DataCenter is correct")
 	assert.Equal(t, "mynetwork", network.Description, "network Description is correct")
 
 }
@@ -51,7 +51,7 @@ func TestNetworksEdit(t *testing.T) {
 	assert.Equal(t, "POST", c.lastMethod, "method is used correct")
 	assert.Equal(t, "network/edit", c.lastPath, "path used is correct")
 	assert.Equal(t, "vl123456", network.ID, "network ID is correct")
-	assert.Equal(t, "Falkenberg", network.Datacenter, "network Datacenter is correct")
+	assert.Equal(t, "Falkenberg", network.DataCenter, "network DataCenter is correct")
 	assert.Equal(t, "mynewnetwork", network.Description, "network Description is correct")
 }
 
@@ -64,7 +64,7 @@ func TestNetworksList(t *testing.T) {
 
 	assert.Equal(t, "GET", c.lastMethod, "method used is correct")
 	assert.Equal(t, "network/list", c.lastPath, "path used is correct")
-	assert.Equal(t, "Falkenberg", (*networks)[0].Datacenter, "network Datacenter is correct")
+	assert.Equal(t, "Falkenberg", (*networks)[0].DataCenter, "network DataCenter is correct")
 	assert.Equal(t, "yes", (*networks)[0].Public, "network is public")
 	assert.Equal(t, "Internet", (*networks)[0].Description, "network Description is correct")
 	assert.Equal(t, "internet-fbg", (*networks)[0].ID, "network ID is correct")

--- a/networks_test.go
+++ b/networks_test.go
@@ -1,0 +1,72 @@
+package glesys
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNetworksCreate(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "network":
+		{ "datacenter": "Falkenberg", "description": "mynetwork", "networkid": "vl123456" }}}`}
+	n := NetworkService{client: c}
+
+	params := CreateNetworkParams{
+		Datacenter:  "Falkenberg",
+		Description: "mynetwork",
+	}
+
+	network, _ := n.Create(context.Background(), params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method is used correct")
+	assert.Equal(t, "network/create", c.lastPath, "path used is correct")
+	assert.Equal(t, "vl123456", network.ID, "network ID is correct")
+	assert.Equal(t, "Falkenberg", network.Datacenter, "network Datacenter is correct")
+	assert.Equal(t, "mynetwork", network.Description, "network Description is correct")
+
+}
+
+func TestNetworksDestroy(t *testing.T) {
+	c := &mockClient{}
+	n := NetworkService{client: c}
+
+	n.Destroy(context.Background(), "vl123456")
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "network/delete", c.lastPath, "path used is correct")
+}
+
+func TestNetworksEdit(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "network":
+		{ "datacenter": "Falkenberg", "description": "mynewnetwork", "networkid": "vl123456" }}}`}
+	n := NetworkService{client: c}
+
+	params := EditNetworkParams{
+		Description: "mynetwork",
+	}
+
+	network, _ := n.Edit(context.Background(), "vl123456", params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method is used correct")
+	assert.Equal(t, "network/edit", c.lastPath, "path used is correct")
+	assert.Equal(t, "vl123456", network.ID, "network ID is correct")
+	assert.Equal(t, "Falkenberg", network.Datacenter, "network Datacenter is correct")
+	assert.Equal(t, "mynewnetwork", network.Description, "network Description is correct")
+}
+
+func TestNetworksList(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "networks":
+	[{ "datacenter": "Falkenberg", "description": "Internet", "networkid": "internet-fbg", "public": "yes"}] } }`}
+	n := NetworkService{client: c}
+
+	networks, _ := n.List(context.Background())
+
+	assert.Equal(t, "GET", c.lastMethod, "method used is correct")
+	assert.Equal(t, "network/list", c.lastPath, "path used is correct")
+	assert.Equal(t, "Falkenberg", (*networks)[0].Datacenter, "network Datacenter is correct")
+	assert.Equal(t, "yes", (*networks)[0].Public, "network is public")
+	assert.Equal(t, "Internet", (*networks)[0].Description, "network Description is correct")
+	assert.Equal(t, "internet-fbg", (*networks)[0].ID, "network ID is correct")
+
+}


### PR DESCRIPTION
Implement calls to the 'network/*' endpoints.

Destroy instead of Delete, to keep the naming consistent with the
servers functions.

Example:
========

```
c := client.NewClient("MYID", "MYTOKEN", "MYAPP/1.0")
n, err := c.Networks.Create(context.Background(),
        glesys.CreateNetworkParams{Datacenter: "Falkenberg",
        Description: "mynetwork"})
```