### PR TITLE
Add call to servers/edit

### DIFF
--- a/servers.go
+++ b/servers.go
@@ -68,6 +68,15 @@ type CreateServerParams struct {
 	Template     string `json:"templatename"`
 }
 
+type EditServerParams struct {
+	Bandwidth   int    `json:"bandwidth,omitempty"`
+	CPU         int    `json:"cpucores,omitempty"`
+	Description string `json:"description,omitempty"`
+	Hostname    string `json:"hostname,omitempty"`
+	Memory      int    `json:"memorysize,omitempty"`
+	Storage     int    `json:"disksize,omitempty"`
+}
+
 // WithDefaults populates the parameters with default values. Existing
 // parameters will not be overwritten.
 func (p CreateServerParams) WithDefaults() CreateServerParams {
@@ -125,6 +134,20 @@ func (s *ServerService) Details(context context.Context, serverID string) (*Serv
 		}
 	}{}
 	err := s.client.get(context, fmt.Sprintf("server/details/serverid/%s/includestate/yes", serverID), &data)
+	return &data.Response.Server, err
+}
+
+// Edit modifies a server
+func (s *ServerService) Edit(context context.Context, serverID string, params EditServerParams) (*ServerDetails, error) {
+	data := struct {
+		Response struct {
+			Server ServerDetails
+		}
+	}{}
+	err := s.client.post(context, "server/edit", &data, struct {
+		EditServerParams
+		ServerID string `json:"serverid"`
+	}{params, serverID})
 	return &data.Response.Server, err
 }
 

--- a/servers_test.go
+++ b/servers_test.go
@@ -97,6 +97,16 @@ func TestServersDetails(t *testing.T) {
 	assert.Equal(t, "Debian 8 64-bit", server.Template, "server Template is correct")
 }
 
+func TestServersEdit(t *testing.T) {
+	c := &mockClient{}
+	s := ServerService{client: c}
+
+	s.Edit(context.Background(), "vz123456", EditServerParams{})
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "server/edit", c.lastPath, "path used is correct")
+}
+
 func TestServersList(t *testing.T) {
 	c := &mockClient{body: `{ "response": { "servers": [{ "serverid": "vz12345" }] } }`}
 	s := ServerService{client: c}


### PR DESCRIPTION
Use the Servers.Edit() to modify the parameters of a server.

Example:

```
sd, err := client.Servers.Edit(context.Background(), "vz123456",
        EditServerParams{CPU: 4, Memory: 1024, Hostname:
        "mynewhostname"}
```