### PR TITLE
Add Networks.IsPublic()

### DIFF
--- a/networks.go
+++ b/networks.go
@@ -72,6 +72,11 @@ func (s *NetworkService) Edit(context context.Context, networkID string, params 
 	return &data.Response.Network, err
 }
 
+// IsPublic return true if network is public
+func (s *Network) IsPublic() bool {
+	return s.Public == "yes"
+}
+
 // List returns a list of Networks available under your account
 func (s *NetworkService) List(context context.Context) (*[]Network, error) {
 	data := struct {

--- a/networks_test.go
+++ b/networks_test.go
@@ -73,6 +73,14 @@ func TestNetworksEdit(t *testing.T) {
 	assert.Equal(t, "mynewnetwork", network.Description, "network Description is correct")
 }
 
+func TestNetworksIsPublic(t *testing.T) {
+	network := Network{Public: "yes"}
+	assert.Equal(t, true, network.IsPublic(), "should be public")
+
+	network.Public = "no"
+	assert.Equal(t, false, network.IsPublic(), "should not be public")
+}
+
 func TestNetworksList(t *testing.T) {
 	c := &mockClient{body: `{ "response": { "networks":
 	[{ "datacenter": "Falkenberg", "description": "Internet", "networkid": "internet-fbg", "public": "yes"}] } }`}


### PR DESCRIPTION
IsPublic() returns true if a Network is public.

Example:
```
network, err := client.Networks.Details(context.Background(), "vl123456")
if err != nil {
  fmt.Println("Error: ", err)
}
if network.IsPublic() {
  fmt.Println("Network is public")
}
```