### PR TITLE
Release 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.2.0] - 2018-11-04
+### Added
+- `Network.IsPublic()` helper. Thanks to @norrland.
+
 ## [2.1.0] - 2017-08-23
 ### Added
 - `NetworkService` and `NetworkAdapterService` are now available with support

--- a/client.go
+++ b/client.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 )
 
-const version = "2.0.0"
+const version = "2.2.0"
 
 type httpClientInterface interface {
 	Do(*http.Request) (*http.Response, error)

--- a/client_test.go
+++ b/client_test.go
@@ -33,7 +33,7 @@ func TestRequestHasCorrectHeaders(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, "application/json", request.Header.Get("Content-Type"), "header Content-Type is correct")
-	assert.Equal(t, "test-application/0.0.1 glesys-go/2.0.0", request.Header.Get("User-Agent"), "header User-Agent is correct")
+	assert.Equal(t, "test-application/0.0.1 glesys-go/2.2.0", request.Header.Get("User-Agent"), "header User-Agent is correct")
 
 	assert.NotEmpty(t, request.Header.Get("Authorization"), "header Authorization is not empty")
 }
@@ -43,7 +43,7 @@ func TestEmptyUserAgent(t *testing.T) {
 
 	request, err := client.newRequest(context.Background(), "GET", "/", nil)
 	assert.NoError(t, err)
-	assert.Equal(t, "glesys-go/2.0.0", request.Header.Get("User-Agent"), "header User-Agent is correct")
+	assert.Equal(t, "glesys-go/2.2.0", request.Header.Get("User-Agent"), "header User-Agent is correct")
 }
 
 func TestGetResponseErrorMessage(t *testing.T) {


### PR DESCRIPTION
- [X]  Add Networks.IsPublic() #8 (merge + changelog)
- [x] Bump version in [client.go](https://github.com/glesys/glesys-go/blob/master/client.go)
- [x] Update release date in [CHANGELOG.md](https://github.com/glesys/glesys-go/blob/master/CHANGELOG.md)