### PR TITLE
Go modules v2 and fix IpList structure in ServerDetails

### DIFF
--- a/servers.go
+++ b/servers.go
@@ -26,9 +26,9 @@ type Server struct {
 
 // User represents a system user when creating servers (currently supported in KVM)
 type User struct {
-	Username     string   `json:"username"`
-	PublicKeys   []string `json:"sshkeys,omitempty"`
-	Password     string   `json:"password,omitempty"`
+	Username   string   `json:"username"`
+	PublicKeys []string `json:"sshkeys,omitempty"`
+	Password   string   `json:"password,omitempty"`
 }
 
 // ServerDetails is a more complete representation of a server
@@ -109,7 +109,7 @@ func (p CreateServerParams) WithDefaults() CreateServerParams {
 // Existing parameters will not be overwritten.
 func (p CreateServerParams) WithUser(username string, publicKeys []string, password string) CreateServerParams {
 
-	p.Users = append(p.Users , User{
+	p.Users = append(p.Users, User{
 		username,
 		publicKeys,
 		password,

--- a/servers_test.go
+++ b/servers_test.go
@@ -60,22 +60,21 @@ func TestCreateServerParamsCustomWithDefaults(t *testing.T) {
 
 func TestCreateServerParamsWithUsers(t *testing.T) {
 	params := CreateServerParams{
-		Bandwidth: 100,
-		CPU: 2,
+		Bandwidth:  100,
+		CPU:        2,
 		DataCenter: "Falkenberg",
-		IPv4: "any",
-		IPv6: "any",
-		Memory: 2048,
-		Storage: 20,
-		Platform: "KVM",
-		Template: "ubuntu-18-04",
-		Hostname: "kvmXXXXXXX",
-
+		IPv4:       "any",
+		IPv6:       "any",
+		Memory:     2048,
+		Storage:    20,
+		Platform:   "KVM",
+		Template:   "ubuntu-18-04",
+		Hostname:   "kvmXXXXXXX",
 	}.WithUser("glesys", []string{"ssh-rsa"}, "password")
 
 	users := []User{{"glesys",
-		 []string{"ssh-rsa"},
-		 "password",
+		[]string{"ssh-rsa"},
+		"password",
 	}}
 
 	assert.Equal(t, 100, params.Bandwidth, "Bandwidth has correct default value")

--- a/v2/client.go
+++ b/v2/client.go
@@ -1,0 +1,158 @@
+package glesys
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const version = "2.4.1"
+
+type httpClientInterface interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type clientInterface interface {
+	get(ctx context.Context, path string, v interface{}) error
+	post(ctx context.Context, path string, v interface{}, params interface{}) error
+}
+
+// Client is used to interact with the GleSYS API
+type Client struct {
+	apiKey     string
+	baseURL    *url.URL
+	httpClient httpClientInterface
+	project    string
+	userAgent  string
+
+	DNSDomains      *DNSDomainService
+	EmailDomains    *EmailDomainService
+	IPs             *IPService
+	LoadBalancers   *LoadBalancerService
+	Servers         *ServerService
+	Networks        *NetworkService
+	NetworkAdapters *NetworkAdapterService
+}
+
+// NewClient creates a new Client for interacting with the GleSYS API. This is
+// the main entrypoint for API interactions.
+func NewClient(project, apiKey, userAgent string) *Client {
+	baseURL, _ := url.Parse("https://api.glesys.com")
+
+	c := &Client{
+		apiKey:     apiKey,
+		baseURL:    baseURL,
+		httpClient: http.DefaultClient,
+		project:    project,
+		userAgent:  userAgent,
+	}
+
+	c.DNSDomains = &DNSDomainService{client: c}
+	c.EmailDomains = &EmailDomainService{client: c}
+	c.IPs = &IPService{client: c}
+	c.LoadBalancers = &LoadBalancerService{client: c}
+	c.Servers = &ServerService{client: c}
+	c.Networks = &NetworkService{client: c}
+	c.NetworkAdapters = &NetworkAdapterService{client: c}
+
+	return c
+}
+
+func (c *Client) get(ctx context.Context, path string, v interface{}) error {
+	request, err := c.newRequest(ctx, "GET", path, nil)
+	if err != nil {
+		return err
+	}
+	return c.do(request, v)
+}
+
+func (c *Client) post(ctx context.Context, path string, v interface{}, params interface{}) error {
+	request, err := c.newRequest(ctx, "POST", path, params)
+	if err != nil {
+		return err
+	}
+	return c.do(request, v)
+}
+
+func (c *Client) newRequest(ctx context.Context, method, path string, params interface{}) (*http.Request, error) {
+	u, err := url.Parse(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.baseURL != nil {
+		u = c.baseURL.ResolveReference(u)
+	}
+
+	buffer := new(bytes.Buffer)
+
+	if params != nil {
+		err = json.NewEncoder(buffer).Encode(params)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	request, err := http.NewRequest(method, u.String(), buffer)
+	if err != nil {
+		return nil, err
+	}
+
+	userAgent := strings.TrimSpace(fmt.Sprintf("%s glesys-go/%s", c.userAgent, version))
+
+	request = request.WithContext(ctx)
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("User-Agent", userAgent)
+	request.SetBasicAuth(c.project, c.apiKey)
+
+	return request, nil
+}
+
+func (c *Client) do(request *http.Request, v interface{}) error {
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return err
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return c.handleResponseError(response)
+	}
+
+	return c.parseResponseBody(response, v)
+}
+
+func (c *Client) handleResponseError(response *http.Response) error {
+	data := struct {
+		Response struct {
+			Status struct {
+				Text string `json:"text"`
+			} `json:"status"`
+		} `json:"response"`
+	}{}
+
+	err := c.parseResponseBody(response, &data)
+	if err != nil {
+		return err
+	}
+
+	return fmt.Errorf("Request failed with HTTP error: %v (%v)", response.StatusCode, strings.TrimSpace(data.Response.Status.Text))
+}
+
+func (c *Client) parseResponseBody(response *http.Response, v interface{}) error {
+	if v == nil {
+		return nil
+	}
+
+	defer response.Body.Close()
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(body, v)
+}

--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -33,7 +33,7 @@ func TestRequestHasCorrectHeaders(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, "application/json", request.Header.Get("Content-Type"), "header Content-Type is correct")
-	assert.Equal(t, "test-application/0.0.1 glesys-go/2.4.0", request.Header.Get("User-Agent"), "header User-Agent is correct")
+	assert.Equal(t, "test-application/0.0.1 glesys-go/2.4.1", request.Header.Get("User-Agent"), "header User-Agent is correct")
 
 	assert.NotEmpty(t, request.Header.Get("Authorization"), "header Authorization is not empty")
 }
@@ -43,7 +43,7 @@ func TestEmptyUserAgent(t *testing.T) {
 
 	request, err := client.newRequest(context.Background(), "GET", "/", nil)
 	assert.NoError(t, err)
-	assert.Equal(t, "glesys-go/2.4.0", request.Header.Get("User-Agent"), "header User-Agent is correct")
+	assert.Equal(t, "glesys-go/2.4.1", request.Header.Get("User-Agent"), "header User-Agent is correct")
 }
 
 func TestGetResponseErrorMessage(t *testing.T) {

--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -1,0 +1,121 @@
+package glesys
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockHTTPClient struct {
+	body        string
+	lastRequest *http.Request
+	statusCode  int
+}
+
+func (c *mockHTTPClient) Do(request *http.Request) (*http.Response, error) {
+	response := http.Response{
+		StatusCode: c.statusCode,
+		Body:       ioutil.NopCloser(bytes.NewBufferString(c.body)),
+	}
+	c.lastRequest = request
+	return &response, nil
+}
+
+func TestRequestHasCorrectHeaders(t *testing.T) {
+	client := NewClient("project-id", "api-key", "test-application/0.0.1")
+
+	request, err := client.newRequest(context.Background(), "GET", "/", nil)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "application/json", request.Header.Get("Content-Type"), "header Content-Type is correct")
+	assert.Equal(t, "test-application/0.0.1 glesys-go/2.4.0", request.Header.Get("User-Agent"), "header User-Agent is correct")
+
+	assert.NotEmpty(t, request.Header.Get("Authorization"), "header Authorization is not empty")
+}
+
+func TestEmptyUserAgent(t *testing.T) {
+	client := NewClient("project-id", "api-key", "")
+
+	request, err := client.newRequest(context.Background(), "GET", "/", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "glesys-go/2.4.0", request.Header.Get("User-Agent"), "header User-Agent is correct")
+}
+
+func TestGetResponseErrorMessage(t *testing.T) {
+	client := NewClient("project-id", "api-key", "test-application/0.0.1")
+
+	json := `{ "response": {"status": { "code": 400, "text": "Unauthorized" } } }`
+	response := http.Response{
+		Body:       ioutil.NopCloser(bytes.NewBufferString(json)),
+		StatusCode: 400,
+	}
+	err := client.handleResponseError(&response)
+	assert.Equal(t, "Request failed with HTTP error: 400 (Unauthorized)", err.Error(), "error message is correct")
+}
+
+func TestDoDoesNotReturnErrorIfStatusIs200(t *testing.T) {
+	payload := `{ "response": { "hello": "world" } }`
+	client := Client{httpClient: &mockHTTPClient{body: payload, statusCode: 200}}
+
+	request, _ := client.newRequest(context.Background(), "GET", "/", nil)
+	err := client.do(request, nil)
+
+	assert.NoError(t, err, "do does not return an error")
+}
+
+func TestDoReturnsErrorIfStatusIsNot200(t *testing.T) {
+	payload := `{ "response": { "foo": "bar" } }`
+	client := Client{httpClient: &mockHTTPClient{body: payload, statusCode: 500}}
+
+	request, _ := client.newRequest(context.Background(), "GET", "/", nil)
+	err := client.do(request, nil)
+
+	assert.Error(t, err, "do returns an error")
+}
+
+func TestDoDecodesTheJsonResponseIntoAStruct(t *testing.T) {
+	payload := `{ "response": { "message": "Hello World" } }`
+	client := Client{httpClient: &mockHTTPClient{body: payload, statusCode: 200}}
+
+	request, _ := client.newRequest(context.Background(), "GET", "/", nil)
+
+	data := struct {
+		Response struct {
+			Message string
+		}
+	}{}
+	err := client.do(request, &data)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "Hello World", data.Response.Message, "JSON was parsed correctly")
+}
+
+func TestGet(t *testing.T) {
+	payload := `{ "response": { "message": "Hello World" } }`
+	mockClient := mockHTTPClient{body: payload, statusCode: 200}
+	client := Client{httpClient: &mockClient}
+
+	data := struct{}{}
+	client.get(context.Background(), "/foo", data)
+
+	assert.Equal(t, "GET", mockClient.lastRequest.Method, "method used is correct")
+}
+
+func TestPost(t *testing.T) {
+	payload := `{ "response": { "message": "Hello World" } }`
+	mockClient := mockHTTPClient{body: payload, statusCode: 200}
+	client := Client{httpClient: &mockClient}
+
+	client.post(context.Background(), "/foo", nil, struct{ Foo string }{Foo: "bar"})
+
+	params := struct{ Foo string }{}
+	json.NewDecoder(mockClient.lastRequest.Body).Decode(&params)
+
+	assert.Equal(t, "POST", mockClient.lastRequest.Method, "method used is correct")
+	assert.Equal(t, "bar", params.Foo, "params are correct")
+}

--- a/v2/dnsdomains.go
+++ b/v2/dnsdomains.go
@@ -1,0 +1,299 @@
+package glesys
+
+import (
+	"context"
+)
+
+// DNSDomainService provides functions to interact with dns domains
+type DNSDomainService struct {
+	client clientInterface
+}
+
+//DNSDomain represents a domain
+type DNSDomain struct {
+	Name                  string           `json:"domainname"`
+	Available             bool             `json:"available,omitempty"`
+	CreateTime            string           `json:"createtime,omitempty"`
+	DisplayName           string           `json:"displayname,omitempty"`
+	Expire                int              `json:"expire,omitempty"`
+	Minimum               int              `json:"minimum,omitempty"`
+	Prices                []DNSDomainPrice `json:"prices,omitempty"`
+	PrimaryNameServer     string           `json:"primarynameserver,omitempty"`
+	RecordCount           int              `json:"recordcount,omitempty"`
+	Refresh               int              `json:"refresh,omitempty"`
+	RegistrarInfo         RegistrarInfo    `json:"registrarinfo,omitempty"`
+	ResponsiblePerson     string           `json:"responsibleperson,omitempty"`
+	Retry                 int              `json:"retry,omitempty"`
+	TTL                   int              `json:"ttl,omitempty"`
+	UsingGlesysNameserver string           `json:"usingglesysnameserver,omitempty"`
+}
+
+// DNSDomainPrice represents the price for a single domain
+type DNSDomainPrice struct {
+	Amount   int    `json:"amount"`
+	Currency string `json:"currency"`
+	Years    int    `json:"years"`
+}
+
+// AddDNSDomainParams - used for adding existing domains to GleSYS
+// use CreateRecords = false to not create additional records.
+type AddDNSDomainParams struct {
+	Name              string `json:"domainname"`
+	CreateRecords     bool   `json:"createrecords,omitempty"`
+	Expire            int    `json:"expire,omitempty"`
+	Minimum           int    `json:"minimum,omitempty"`
+	PrimaryNameServer string `json:"primarynameserver,omitempty"`
+	Refresh           int    `json:"refresh,omitempty"`
+	ResponsiblePerson string `json:"responsibleperson,omitempty"`
+	Retry             int    `json:"retry,omitempty"`
+	TTL               int    `json:"ttl,omitempty"`
+}
+
+// EditDNSDomainParams - used when editing domain parameters
+type EditDNSDomainParams struct {
+	Name              string `json:"domainname"`
+	Expire            int    `json:"expire,omitempty"`
+	Minimum           int    `json:"minimum,omitempty"`
+	PrimaryNameServer string `json:"primarynameserver,omitempty"`
+	Refresh           int    `json:"refresh,omitempty"`
+	ResponsiblePerson string `json:"responsibleperson,omitempty"`
+	Retry             int    `json:"retry,omitempty"`
+	TTL               int    `json:"ttl,omitempty"`
+}
+
+// RegistrarInfo contains information about the registrar for the domain
+type RegistrarInfo struct {
+	AutoRenew        string `json:"autorenew"`
+	State            string `json:"state"`
+	StateDescription string `json:"statedescription,omitempty"`
+	Expire           string `json:"expire,omitempty"`
+	TLD              string `json:"tld,omitempty"`
+	InvoiceNumber    string `json:"invoicenumber,omitempty"`
+}
+
+// RegisterDNSDomainParams - parameters used when registering a domain
+type RegisterDNSDomainParams struct {
+	Name               string `json:"domainname"`
+	Address            string `json:"address"`
+	City               string `json:"city"`
+	Country            string `json:"country"`
+	Email              string `json:"email"`
+	Firstname          string `json:"firstname"`
+	Lastname           string `json:"lastname"`
+	OrganizationNumber int    `json:"organizationnumber"`
+	Organization       string `json:"organization"`
+	PhoneNumber        string `json:"phonenumber"`
+	ZipCode            string `json:"zipcode"`
+
+	FaxNumber string `json:"fax,omitempty"`
+	NumYears  int    `json:"numyears,omitempty"`
+}
+
+// DeleteDNSDomainParams - parameters for deleting a domain from the dns system.
+// Set ForceDeleteEmail to true, to delete a domain AND email accounts for the domain.
+type DeleteDNSDomainParams struct {
+	Name             string `json:"domainname"`
+	ForceDeleteEmail string `json:"forcedeleteemail,omitempty"`
+}
+
+// RenewDNSDomainParams - parameters to send when renewing a domain.
+type RenewDNSDomainParams struct {
+	Name     string `json:"domainname"`
+	NumYears int    `json:"numyears"`
+}
+
+// SetAutoRenewParams - parameters to send for renewing a domain automatically.
+type SetAutoRenewParams struct {
+	Name         string `json:"domainname"`
+	SetAutoRenew string `json:"setautorenew"`
+}
+
+// DNSDomainRecord - data in the domain
+type DNSDomainRecord struct {
+	DomainName string `json:"domainname"`
+	Data       string `json:"data"`
+	Host       string `json:"host"`
+	RecordID   int    `json:"recordid"`
+	TTL        int    `json:"ttl"`
+	Type       string `json:"type"`
+}
+
+// AddRecordParams - parameters for updating domain records
+type AddRecordParams struct {
+	DomainName string `json:"domainname"`
+	Data       string `json:"data"`
+	Host       string `json:"host"`
+	Type       string `json:"type"`
+	TTL        int    `json:"ttl,omitempty"`
+}
+
+// UpdateRecordParams - parameters for updating domain records
+type UpdateRecordParams struct {
+	RecordID int    `json:"recordid"`
+	Data     string `json:"data,omitempty"`
+	Host     string `json:"host,omitempty"`
+	Type     string `json:"type,omitempty"`
+	TTL      int    `json:"ttl,omitempty"`
+}
+
+// ChangeNameserverParams - parameters for updating the nameservers for domain
+type ChangeNameserverParams struct {
+	DomainName string `json:"domainname"`
+	NS1        string `json:"NS1"`
+	NS2        string `json:"NS2"`
+	NS3        string `json:"NS3,omitempty"`
+	NS4        string `json:"NS4,omitempty"`
+}
+
+// Available - checks if the domain is available
+func (s *DNSDomainService) Available(context context.Context, search string) (*[]DNSDomain, error) {
+	data := struct {
+		Response struct {
+			Domain []DNSDomain
+		}
+	}{}
+	err := s.client.post(context, "domain/available", &data, search)
+	return &data.Response.Domain, err
+}
+
+// AddDNSDomain - add an existing domain to your GleSYS account
+func (s *DNSDomainService) AddDNSDomain(context context.Context, params AddDNSDomainParams) (*DNSDomain, error) {
+	data := struct {
+		Response struct {
+			Domain DNSDomain
+		}
+	}{}
+	err := s.client.post(context, "domain/add", &data, params)
+	return &data.Response.Domain, err
+}
+
+// Delete - deletes a domain from the dns system
+func (s *DNSDomainService) Delete(context context.Context, params DeleteDNSDomainParams) error {
+	return s.client.post(context, "domain/delete", nil, params)
+}
+
+// Details - return details about the domain
+func (s *DNSDomainService) Details(context context.Context, domainname string) (*DNSDomain, error) {
+	data := struct {
+		Response struct {
+			Domain DNSDomain
+		}
+	}{}
+	err := s.client.post(context, "domain/details", &data, struct {
+		Name string `json:"domainname"`
+	}{domainname})
+	return &data.Response.Domain, err
+}
+
+// Edit - edit domain parameters
+func (s *DNSDomainService) Edit(context context.Context, params EditDNSDomainParams) (*DNSDomain, error) {
+	data := struct {
+		Response struct {
+			Domain DNSDomain
+		}
+	}{}
+	err := s.client.post(context, "domain/edit", &data, params)
+	return &data.Response.Domain, err
+}
+
+// List - return a list of all domains in your account
+func (s *DNSDomainService) List(context context.Context) (*[]DNSDomain, error) {
+	data := struct {
+		Response struct {
+			Domains []DNSDomain
+		}
+	}{}
+	err := s.client.get(context, "domain/list", &data)
+	return &data.Response.Domains, err
+}
+
+// Register - Register a domain
+func (s *DNSDomainService) Register(context context.Context, params RegisterDNSDomainParams) (*DNSDomain, error) {
+	data := struct {
+		Response struct {
+			Domain DNSDomain
+		}
+	}{}
+	err := s.client.post(context, "domain/register", &data, params)
+	return &data.Response.Domain, err
+}
+
+// Renew - Renew a domain
+func (s *DNSDomainService) Renew(context context.Context, params RenewDNSDomainParams) (*DNSDomain, error) {
+	data := struct {
+		Response struct {
+			Domain DNSDomain
+		}
+	}{}
+	err := s.client.post(context, "domain/renew", &data, params)
+	return &data.Response.Domain, err
+}
+
+// SetAutoRenew - Set a domain to renew automatically
+func (s *DNSDomainService) SetAutoRenew(context context.Context, params SetAutoRenewParams) (*DNSDomain, error) {
+	data := struct {
+		Response struct {
+			Domain DNSDomain
+		}
+	}{}
+	err := s.client.post(context, "domain/setautorenew", &data, params)
+	return &data.Response.Domain, err
+}
+
+// Transfer - Transfer a domain
+func (s *DNSDomainService) Transfer(context context.Context, params RegisterDNSDomainParams) (*DNSDomain, error) {
+	data := struct {
+		Response struct {
+			Domain DNSDomain
+		}
+	}{}
+	err := s.client.post(context, "domain/transfer", &data, params)
+	return &data.Response.Domain, err
+}
+
+// ListRecords - return a list of all records for domain
+func (s *DNSDomainService) ListRecords(context context.Context, domainname string) (*[]DNSDomainRecord, error) {
+	data := struct {
+		Response struct {
+			Records []DNSDomainRecord
+		}
+	}{}
+	err := s.client.post(context, "domain/listrecords", &data, struct {
+		Name string `json:"domainname"`
+	}{domainname})
+	return &data.Response.Records, err
+}
+
+// AddRecord - add a domain record
+func (s *DNSDomainService) AddRecord(context context.Context, params AddRecordParams) (*DNSDomainRecord, error) {
+	data := struct {
+		Response struct {
+			Record DNSDomainRecord
+		}
+	}{}
+	err := s.client.post(context, "domain/addrecord", &data, params)
+	return &data.Response.Record, err
+}
+
+// UpdateRecord - update a domain record
+func (s *DNSDomainService) UpdateRecord(context context.Context, params UpdateRecordParams) (*DNSDomainRecord, error) {
+	data := struct {
+		Response struct {
+			Record DNSDomainRecord
+		}
+	}{}
+	err := s.client.post(context, "domain/updaterecord", &data, params)
+	return &data.Response.Record, err
+}
+
+// DeleteRecord deletes a record
+func (s *DNSDomainService) DeleteRecord(context context.Context, recordID int) error {
+	return s.client.post(context, "domain/deleterecord", nil, struct {
+		RecordID int `json:"recordid"`
+	}{recordID})
+}
+
+// ChangeNameservers - change the nameservers for domain
+func (s *DNSDomainService) ChangeNameservers(context context.Context, params ChangeNameserverParams) error {
+	return s.client.post(context, "domain/changenameservers", nil, params)
+}

--- a/v2/dnsdomains_test.go
+++ b/v2/dnsdomains_test.go
@@ -1,0 +1,294 @@
+package glesys
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDnsDomainsAdd(t *testing.T) {
+	c := &mockClient{body: `{"response": {"domain": {"domainname": "example.com",
+	  "createtime": "2019-07-02T21:55:18+02:00", "displayname": "example.com",
+	  "recordcount": 9, "registrarinfo": "None", "usingglesysnameserver": "no"}}}`}
+	d := DNSDomainService{client: c}
+
+	params := AddDNSDomainParams{
+		Name:          "example.com",
+		CreateRecords: false,
+	}
+
+	domain, _ := d.AddDNSDomain(context.Background(), params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method is used correct")
+	assert.Equal(t, "domain/add", c.lastPath, "path used is correct")
+	assert.Equal(t, "example.com", domain.Name, "Domain name is correct")
+	assert.Equal(t, 9, domain.RecordCount, "Domain has the correct number of records")
+	assert.Equal(t, "no", domain.UsingGlesysNameserver, "Domain is not using glesys nameservers")
+}
+
+func TestDnsDomainsDeleteDomain(t *testing.T) {
+	c := &mockClient{}
+	d := DNSDomainService{client: c}
+
+	params := DeleteDNSDomainParams{
+		Name: "example.com",
+	}
+
+	d.Delete(context.Background(), params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method is used correct")
+	assert.Equal(t, "domain/delete", c.lastPath, "path used is correct")
+}
+
+func TestDnsDomainsEdit(t *testing.T) {
+	c := &mockClient{body: `{"response": { "domain": {"domainname": "example.com",
+          "createtime": "2010-07-13T11:13:50+02:00", "displayname": "example.com",
+          "recordcount": 9, "usingglesysnameserver": "yes",
+          "primarynameserver": "ns1.namesystem.se.",
+          "responsibleperson": "registry.glesys.se.",
+          "ttl": 3600, "refresh": 10800, "retry": 2400, "expire": 1814400, "minimum": 10800,
+          "contactinfo": "None", "registrarinfo": {"state": "OK", "statedescription": "", "expire": "2038-01-19",
+            "autorenew": "yes", "tld": "com", "invoicenumber": "None"}}}}`}
+	d := DNSDomainService{client: c}
+
+	params := EditDNSDomainParams{
+		Name:  "example.com",
+		Retry: 2400,
+	}
+
+	domain, _ := d.Edit(context.Background(), params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method is used correct")
+	assert.Equal(t, "domain/edit", c.lastPath, "path used is correct")
+	assert.Equal(t, "example.com", domain.Name, "Domain name is correct")
+	assert.Equal(t, 2400, domain.Retry, "Domain Retry correct")
+}
+
+func TestDnsDomainsAvailable(t *testing.T) {
+	c := &mockClient{body: `{"response": {"domain": [ {"domainname": "example.com",
+	   "available": true,
+	   "prices": [{"amount": 123, "currency": "SEK", "years": 1}, {"amount": 1230, "currency": "SEK", "years": 10}]
+           }]}}`}
+	d := DNSDomainService{client: c}
+
+	domains, _ := d.Available(context.Background(), "example.com")
+
+	assert.Equal(t, "POST", c.lastMethod, "method is used correct")
+	assert.Equal(t, "domain/available", c.lastPath, "path used is correct")
+	assert.Equal(t, true, (*domains)[0].Available, "Domain is available")
+	assert.Equal(t, 1230, (*domains)[0].Prices[1].Amount, "Domain amount is correct")
+}
+
+func TestDnsDomainsDetails(t *testing.T) {
+	c := &mockClient{body: `{"response": { "domain": {"domainname": "example.com",
+          "createtime": "2010-07-13T11:13:50+02:00", "displayname": "example.com",
+          "recordcount": 9, "usingglesysnameserver": "yes",
+          "primarynameserver": "ns1.namesystem.se.",
+          "responsibleperson": "registry.glesys.se.",
+          "ttl": 3600, "refresh": 10800, "retry": 2700, "expire": 1814400, "minimum": 10800,
+          "contactinfo": "None", "registrarinfo": {"state": "OK", "statedescription": "", "expire": "2038-01-19",
+            "autorenew": "yes", "tld": "com", "invoicenumber": "None"}}}}`}
+	d := DNSDomainService{client: c}
+
+	domain, _ := d.Details(context.Background(), "example.com")
+
+	assert.Equal(t, "POST", c.lastMethod, "method is used correct")
+	assert.Equal(t, "domain/details", c.lastPath, "path used is correct")
+	assert.Equal(t, "example.com", domain.Name, "Domain name is correct")
+	assert.Equal(t, 3600, domain.TTL, "Domain has the correct TTL")
+	assert.Equal(t, "yes", domain.UsingGlesysNameserver, "Domain is using glesys nameservers")
+}
+
+func TestDnsDomainsList(t *testing.T) {
+	c := &mockClient{body: `{"response": { "domains": [{"domainname": "example.com",
+          "createtime": "2010-07-13T11:13:50+02:00", "displayname": "example.com",
+          "recordcount": 4, "registrarinfo": {"state": "OK", "statedescription": "", "expire": "2038-01-19",
+          "autorenew": "yes", "tld": "com", "invoicenumber": "None"}}]}}`}
+
+	d := DNSDomainService{client: c}
+
+	domains, _ := d.List(context.Background())
+
+	assert.Equal(t, "GET", c.lastMethod, "method used is correct")
+	assert.Equal(t, "domain/list", c.lastPath, "path used is correct")
+	assert.Equal(t, "example.com", (*domains)[0].Name, "Domain name is correct")
+	assert.Equal(t, 4, (*domains)[0].RecordCount, "record count correct")
+	assert.Equal(t, "yes", (*domains)[0].RegistrarInfo.AutoRenew, "Domain AutoRenew is set")
+}
+
+func TestDnsDomainsRegister(t *testing.T) {
+	c := &mockClient{body: `{"response": { "domain": {"domainname": "example.com",
+          "createtime": "2010-07-13T11:13:50+02:00", "displayname": "example.com",
+          "recordcount": 4, "registrarinfo": {"state": "REGISTER", "statedescription": "", "expire": "2038-01-19",
+          "autorenew": "yes", "tld": "com", "invoicenumber": "None"}}}}`}
+
+	d := DNSDomainService{client: c}
+	params := RegisterDNSDomainParams{
+		Name:               "example.com",
+		Firstname:          "Alice",
+		Lastname:           "Smith",
+		Email:              "alice@example.com",
+		Address:            "Badhusvägen 45",
+		City:               "Falkenberg",
+		ZipCode:            "31132",
+		Country:            "SE",
+		Organization:       "Internetz",
+		OrganizationNumber: 13337,
+	}
+
+	domain, _ := d.Register(context.Background(), params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "domain/register", c.lastPath, "path used is correct")
+	assert.Equal(t, "REGISTER", domain.RegistrarInfo.State, "Domain is in correct state")
+}
+
+func TestDnsDomainsRenew(t *testing.T) {
+	c := &mockClient{body: `{"response": { "domain": {"domainname": "example.com",
+          "createtime": "2010-07-13T11:13:50+02:00", "displayname": "example.com",
+          "recordcount": 4, "registrarinfo": {"state": "RENEW", "statedescription": "", "expire": "2038-01-19",
+          "autorenew": "yes", "tld": "com", "invoicenumber": "None"}}}}`}
+
+	d := DNSDomainService{client: c}
+	params := RenewDNSDomainParams{
+		Name:     "example.com",
+		NumYears: 1,
+	}
+
+	domain, _ := d.Renew(context.Background(), params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "domain/renew", c.lastPath, "path used is correct")
+	assert.Equal(t, "RENEW", domain.RegistrarInfo.State, "Domain is in correct state")
+}
+
+func TestDnsDomainsSetAutoRenew(t *testing.T) {
+	c := &mockClient{body: `{"response": { "domain": {"domainname": "example.com",
+          "createtime": "2010-07-13T11:13:50+02:00", "displayname": "example.com",
+          "recordcount": 4, "registrarinfo": {"state": "RENEW", "statedescription": "", "expire": "2038-01-19",
+          "autorenew": "yes", "tld": "com", "invoicenumber": "None"}}}}`}
+
+	d := DNSDomainService{client: c}
+	params := SetAutoRenewParams{
+		Name:         "example.com",
+		SetAutoRenew: "yes",
+	}
+
+	domain, _ := d.SetAutoRenew(context.Background(), params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "domain/setautorenew", c.lastPath, "path used is correct")
+	assert.Equal(t, "yes", domain.RegistrarInfo.AutoRenew, "Domain is set to renew automatically.")
+}
+
+func TestDnsDomainsTransfer(t *testing.T) {
+	c := &mockClient{body: `{"response": { "domain": {"domainname": "example.com",
+          "createtime": "2010-07-13T11:13:50+02:00", "displayname": "example.com",
+          "recordcount": 4, "registrarinfo": {"state": "TRANSFER", "statedescription": "", "expire": "2038-01-19",
+          "autorenew": "yes", "tld": "com", "invoicenumber": "None"}}}}`}
+
+	d := DNSDomainService{client: c}
+	params := RegisterDNSDomainParams{
+		Name:               "example.com",
+		Firstname:          "Alice",
+		Lastname:           "Smith",
+		Email:              "alice@example.com",
+		Address:            "Badhusvägen 45",
+		City:               "Falkenberg",
+		ZipCode:            "31132",
+		Country:            "SE",
+		Organization:       "Internetz",
+		OrganizationNumber: 13337,
+	}
+
+	domain, _ := d.Transfer(context.Background(), params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "domain/transfer", c.lastPath, "path used is correct")
+	assert.Equal(t, "TRANSFER", domain.RegistrarInfo.State, "Domain is in correct state")
+}
+
+func TestDnsDomainsAddRecord(t *testing.T) {
+	c := &mockClient{body: `{"response": { "record":
+          {"recordid": 1234569, "domainname": "example.com", "host": "test", "type": "A", "data": "127.0.0.1", "ttl": 3600}
+	}}`}
+
+	params := AddRecordParams{
+		DomainName: "example.com",
+		Host:       "test",
+		Data:       "127.0.0.1",
+		Type:       "A",
+	}
+
+	d := DNSDomainService{client: c}
+
+	record, _ := d.AddRecord(context.Background(), params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "domain/addrecord", c.lastPath, "path used is correct")
+	assert.Equal(t, "test", (*record).Host, "Record host is correct")
+	assert.Equal(t, "127.0.0.1", (*record).Data, "Record data is correct")
+}
+
+func TestDnsDomainsListRecords(t *testing.T) {
+	c := &mockClient{body: `{"response": { "records": [
+	  {"recordid": 1234567, "domainname": "example.com", "host": "www", "type": "A", "data": "127.0.0.1", "ttl": 3600},
+          {"recordid": 1234568, "domainname": "example.com", "host": "mail", "type": "A", "data": "127.0.0.3", "ttl": 3600}
+	]}}`}
+
+	d := DNSDomainService{client: c}
+
+	records, _ := d.ListRecords(context.Background(), "example.com")
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "domain/listrecords", c.lastPath, "path used is correct")
+	assert.Equal(t, "www", (*records)[0].Host, "Record host is correct")
+	assert.Equal(t, "127.0.0.3", (*records)[1].Data, "Record data is correct")
+}
+
+func TestDnsDomainsUpdateRecord(t *testing.T) {
+	c := &mockClient{body: `{"response": { "record":
+          {"recordid": 1234567, "domainname": "example.com", "host": "mail", "type": "A", "data": "127.0.0.3", "ttl": 3600}
+	}}`}
+
+	params := UpdateRecordParams{
+		RecordID: 1234567,
+		Data:     "127.0.0.3",
+	}
+
+	d := DNSDomainService{client: c}
+
+	record, _ := d.UpdateRecord(context.Background(), params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "domain/updaterecord", c.lastPath, "path used is correct")
+	assert.Equal(t, "mail", (*record).Host, "Record host is correct")
+	assert.Equal(t, "127.0.0.3", (*record).Data, "Record data is correct")
+}
+
+func TestDnsDomainsDeleteRecord(t *testing.T) {
+	c := &mockClient{}
+	d := DNSDomainService{client: c}
+
+	d.DeleteRecord(context.Background(), 1234567)
+
+	assert.Equal(t, "POST", c.lastMethod, "method is used correct")
+	assert.Equal(t, "domain/deleterecord", c.lastPath, "path used is correct")
+}
+
+func TestDnsDomainsChangeNameservers(t *testing.T) {
+	c := &mockClient{}
+	d := DNSDomainService{client: c}
+
+	params := ChangeNameserverParams{
+		DomainName: "example.com",
+		NS1:        "ns1.namesystem.se.",
+		NS2:        "ns2.example.com.",
+	}
+
+	d.ChangeNameservers(context.Background(), params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method is used correct")
+	assert.Equal(t, "domain/changenameservers", c.lastPath, "path used is correct")
+}

--- a/v2/doc.go
+++ b/v2/doc.go
@@ -1,0 +1,30 @@
+// Package glesys is the official Go client for interacting with the GleSYS API.
+//
+// Please note that only a subset of features available in the GleSYS API has
+// been implemented. We greatly appreciate contributions.
+//
+// Getting Started
+//
+// To get started you need to signup for a GleSYS Cloud account and create an
+// API key. Signup is available at https://glesys.com/signup and API keys can be
+// created at https://customer.glesys.com.
+//
+//     client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+//
+// CL12345 is the key of the Project you want to work with.
+//
+// To be able to monitor usage and help track down issues, we encourage you to
+// provide a user agent string identifying your application or library.
+// Recommended syntax is "my-library/version" or "www.example.com".
+//
+// The different modules of the GleSYS API are available on the client.
+// For example:
+//
+//     client.EmailDomains.Overview(...)
+//     client.IPs.List(...)
+//     client.NetworkAdapters.Create(...)
+//     client.Networks.Create(...)
+//     client.Servers.Create(...)
+//
+// More examples provided below.
+package glesys

--- a/v2/doc_test.go
+++ b/v2/doc_test.go
@@ -1,0 +1,465 @@
+package glesys_test
+
+import (
+	"context"
+	"fmt"
+
+	glesys "github.com/glesys/glesys-go/v2"
+)
+
+func ExampleEmailDomainService_Overview() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	// NOTE: All parameters in OverviewParams are optional and can be omitted.
+	overview, _ := client.EmailDomains.Overview(context.Background(), glesys.OverviewParams{
+		Filter: "example.com",
+		Page:   1,
+	})
+
+	fmt.Printf("%#v", overview)
+}
+
+func ExampleEmailDomainService_GlobalQuota() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	// NOTE: The GlobalQuota parameter can be omitted to only fetch the current value.
+	globalquota, _ := client.EmailDomains.GlobalQuota(context.Background(), glesys.GlobalQuotaParams{
+		GlobalQuota: 20480,
+	})
+
+	fmt.Println(globalquota.Usage)
+	fmt.Println(globalquota.Max)
+}
+
+func ExampleEmailDomainService_List() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	// NOTE: The filter in ListEmailsParams is optional and can be omitted.
+	list, _ := client.EmailDomains.List(context.Background(), "example.com", glesys.ListEmailsParams{
+		Filter: "user@example.com",
+	})
+
+	fmt.Printf("%#v\n", list)
+}
+
+func ExampleEmailDomainService_EditAccount() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	// NOTE: All parameters are optional and can be omitted.
+	editaccount, _ := client.EmailDomains.EditAccount(context.Background(), "user@example.com", glesys.EditAccountParams{
+		AntiSpamLevel:      3,
+		AntiVirus:          "yes",
+		Password:           "SuperSecretPassword",
+		AutoRespond:        "yes",
+		AutoRespondMessage: "Your Automatic Response",
+		Quota:              400,
+		RejectSpam:         "yes",
+	})
+
+	fmt.Printf("%#v\n", editaccount)
+}
+
+func ExampleEmailDomainService_Delete() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	// NOTE: The email parameter can be both an account and an alias.
+	client.EmailDomains.Delete(context.Background(), "user@example.com")
+}
+
+func ExampleEmailDomainService_CreateAccount() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	// NOTE: All parameters except for EmailAccount and Password are optional and can be omitted.
+	createaccount, _ := client.EmailDomains.CreateAccount(context.Background(), glesys.CreateAccountParams{
+		EmailAccount:       "new_user@example.com",
+		Password:           "SuperSecretPassword",
+		AntiSpamLevel:      3,
+		AntiVirus:          "yes",
+		AutoRespond:        "yes",
+		AutoRespondMessage: "Your Automatic Response",
+		Quota:              400,
+		RejectSpam:         "yes",
+	})
+
+	fmt.Printf("%#v\n", createaccount)
+}
+
+func ExampleEmailQuota() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	quota, _ := client.EmailDomains.Quota(context.Background(), "user@example.com")
+
+	fmt.Printf("%#v\n", quota)
+}
+
+func ExampleEmailDomainService_CreateAlias() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	alias, _ := client.EmailDomains.CreateAlias(context.Background(), glesys.EmailAliasParams{
+		EmailAlias: "alias@example.com",
+		GoTo:       "user@example.com",
+	})
+
+	fmt.Printf("%#v\n", alias)
+}
+
+func ExampleEmailDomainService_EditAlias() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	alias, _ := client.EmailDomains.EditAlias(context.Background(), glesys.EmailAliasParams{
+		EmailAlias: "alias@example.com",
+		GoTo:       "another_user@example.com",
+	})
+
+	fmt.Printf("%#v\n", alias)
+}
+
+func ExampleEmailDomainService_Costs() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	costs, _ := client.EmailDomains.Costs(context.Background())
+
+	fmt.Printf("%#v\n", costs)
+}
+
+func ExampleIPService_Available() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	ips, _ := client.IPs.Available(context.Background(), glesys.AvailableIPsParams{
+		DataCenter: "Falkenberg",
+		Platform:   "OpenVZ",
+		Version:    4,
+	})
+
+	for _, ip := range *ips {
+		fmt.Println(ip.Address)
+	}
+}
+
+func ExampleIPService_Release() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	client.IPs.Release(context.Background(), "1.2.3.4")
+}
+
+func ExampleIPService_Reserve() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	ip, _ := client.IPs.Reserve(context.Background(), "1.2.3.4")
+
+	fmt.Println(ip.Address)
+}
+
+func ExampleIPService_Reserved() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	ips, _ := client.IPs.Reserved(context.Background())
+
+	for _, ip := range *ips {
+		fmt.Println(ip.Address)
+	}
+}
+
+func ExampleLoadBalancerService_Create() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	loadbalancer, _ := client.LoadBalancers.Create(context.Background(),
+		glesys.CreateLoadBalancerParams{
+			DataCenter: "Falkenberg",
+			Name:       "mylb-1",
+		})
+
+	fmt.Println(loadbalancer.ID)
+}
+
+func ExampleLoadBalancerService_Destroy() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	client.LoadBalancers.Destroy(context.Background(), "lb123456")
+}
+
+func ExampleLoadBalancerService_Details() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	loadbalancer, _ := client.LoadBalancers.Details(context.Background(), "lb123456")
+
+	fmt.Println(loadbalancer.Name)
+}
+
+func ExampleLoadBalancerService_AddBackend() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	loadbalancer, _ := client.LoadBalancers.AddBackend(context.Background(), "lb123456",
+		glesys.AddBackendParams{
+			Name: "mywebbackend",
+			Mode: "http",
+		})
+
+	// print the name of all backends for the LoadBalancer
+	for i := range (*loadbalancer).BackendsList {
+		be := (*loadbalancer).BackendsList[i]
+		fmt.Println("Name:", be.Name)
+	}
+}
+
+func ExampleLoadBalancerService_AddTarget() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	loadbalancer, _ := client.LoadBalancers.AddTarget(context.Background(), "lb123456",
+		glesys.AddTargetParams{
+			Backend:  "mywebbackend",
+			Name:     "web01",
+			Port:     8080,
+			TargetIP: "172.17.0.10",
+			Weight:   5,
+		})
+
+	for i := range (*loadbalancer).BackendsList {
+		be := (*loadbalancer).BackendsList[i]
+		for k := range be.Targets {
+			fmt.Printf("Backend: %s, Target: %s\n", be.Name, be.Targets[k].Name)
+		}
+	}
+}
+
+func ExampleLoadBalancerService_DisableTarget() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	loadbalancer, _ := client.LoadBalancers.DisableTarget(context.Background(), "lb123456",
+		glesys.ToggleTargetParams{
+			Backend: "mywebbackend",
+			Name:    "web01",
+		})
+
+	for i := range (*loadbalancer).BackendsList {
+		be := (*loadbalancer).BackendsList[i]
+		for k := range be.Targets {
+			fmt.Printf("Backend: %s, Target: %s, Status: %s\n", be.Name, be.Targets[k].Name, be.Targets[k].Status)
+		}
+	}
+}
+
+func ExampleLoadBalancerService_AddFrontend() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	loadbalancer, _ := client.LoadBalancers.AddFrontend(context.Background(), "lb123456",
+		glesys.AddFrontendParams{
+			Name:           "mywebfrontend",
+			Backend:        "mywebbackend",
+			Port:           80,
+			ClientTimeout:  4000,
+			MaxConnections: 1000,
+		})
+
+	// print the name of all frontends for the LoadBalancer
+	for i := range (*loadbalancer).FrontendsList {
+		fe := (*loadbalancer).FrontendsList[i]
+		fmt.Println("Name:", fe.Name)
+	}
+}
+
+func ExampleLoadBalancerService_AddCertificate() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	mybase64pem := "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCm15Y2VydAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tQkVHSU4gUFJJVkFURSBLRVktLS0tLQpteWtleQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg=="
+
+	client.LoadBalancers.AddCertificate(context.Background(), "lb123456", glesys.AddCertificateParams{
+		Name:        "mycert",
+		Certificate: mybase64pem,
+	})
+}
+
+func ExampleLoadBalancerService_ListCertificates() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	certlist, _ := client.LoadBalancers.ListCertificates(context.Background(), "lb123456")
+
+	for _, cert := range *certlist {
+		fmt.Println("Certificate:", cert)
+	}
+}
+
+func ExampleLoadBalancerService_RemoveCertificate() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	err := client.LoadBalancers.RemoveCertificate(context.Background(), "lb123456", "mycert")
+
+	if err != nil {
+		fmt.Printf("Error removing certificate: %s\n", err)
+	}
+}
+
+func ExampleNetworkAdapterService_Create() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	// NOTE: All parameters except ServerID are optional, the values shown below
+	// are defaults and can be omitted.
+
+	networkAdapter, _ := client.NetworkAdapters.Create(context.Background(), glesys.CreateNetworkAdapterParams{
+		AdapterType: "VMXNET 3", // "E1000" also available
+		Bandwidth:   100,
+		NetworkID:   "internet-fbg",
+		ServerID:    "wps123456",
+	})
+
+	fmt.Println(networkAdapter.ID)
+}
+
+func ExampleNetworkAdapterService_Destroy() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	client.NetworkAdapters.Destroy(context.Background(), "f590b422-453c-4fc4-99e7-af2b72a60f63")
+}
+
+func ExampleNetworkAdapterService_Details() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	networkAdapter, _ := client.NetworkAdapters.Details(context.Background(), "f590b422-453c-4fc4-99e7-af2b72a60f63")
+
+	fmt.Println(networkAdapter.Name)
+}
+
+func ExampleNetworkAdapterService_Edit() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	// NOTE: Changes are not reflected immediately.
+
+	networkAdapter, _ := client.NetworkAdapters.Edit(context.Background(), "f590b422-453c-4fc4-99e7-af2b72a60f63", glesys.EditNetworkAdapterParams{
+		Bandwidth: 200,
+		NetworkID: "vl12345",
+	})
+
+	fmt.Println(networkAdapter.Name)
+}
+
+func ExampleNetworkService_Create() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	network, _ := client.Networks.Create(context.Background(), glesys.CreateNetworkParams{
+		DataCenter:  "Falkenberg",
+		Description: "My Network",
+	})
+
+	fmt.Println(network.ID)
+}
+
+func ExampleNetworkService_Destroy() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	client.Networks.Destroy(context.Background(), "vl123456")
+}
+
+func ExampleNetworkService_Details() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	network, _ := client.Networks.Details(context.Background(), "vl123456")
+
+	fmt.Println(network.Description)
+}
+
+func ExampleNetworkService_Edit() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	network, _ := client.Networks.Edit(context.Background(), "vl123456", glesys.EditNetworkParams{
+		Description: "My Private Network",
+	})
+
+	fmt.Println(network.Description)
+}
+
+func ExampleNetworkService_List() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	networks, _ := client.Networks.List(context.Background())
+
+	for _, network := range *networks {
+		fmt.Println(network.ID)
+	}
+}
+
+func ExampleServerService_Create() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	server, _ := client.Servers.Create(context.Background(), glesys.CreateServerParams{
+		Bandwidth:    100,
+		CampaignCode: "",
+		CPU:          2,
+		DataCenter:   "Falkenberg",
+		Description:  "",
+		Hostname:     "my-hostname",
+		IPv4:         "any",
+		IPv6:         "any",
+		Memory:       2048,
+		Password:     "...",
+		Platform:     "OpenVZ",
+		PublicKey:    "...",
+		Storage:      50,
+		Template:     "Debian 8 64-bit",
+	})
+
+	fmt.Println(server.ID)
+
+	// NOTE: You can also use the WithDefaults() to provide defaults values for
+	// all required parameters except Password (or PublicKey)
+
+	server2, _ := client.Servers.Create(context.Background(), glesys.CreateServerParams{
+		Password: "...",
+	}.WithDefaults())
+
+	fmt.Println(server2.ID)
+}
+
+func ExampleServerService_Destroy() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	client.Servers.Destroy(context.Background(), "vz12345", glesys.DestroyServerParams{
+		KeepIP: true, // KeepIP defaults to false
+	})
+}
+
+func ExampleServerService_Details() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	server, _ := client.Servers.Details(context.Background(), "vz12345")
+
+	fmt.Println(server.Hostname)
+}
+
+func ExampleServerService_Edit() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	server, _ := client.Servers.Edit(context.Background(), "vz12345", glesys.EditServerParams{
+		Bandwidth:   100,
+		CPU:         4,
+		Description: "Web Server",
+		Hostname:    "example.com",
+		Memory:      4096,
+		Storage:     250,
+	})
+
+	fmt.Println(server.ID)
+}
+
+func ExampleServerService_List() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	servers, _ := client.Servers.List(context.Background())
+
+	for _, server := range *servers {
+		fmt.Println(server.Hostname)
+	}
+}
+
+func ExampleServerService_Start() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	client.Servers.Start(context.Background(), "vz12345")
+}
+
+func ExampleServerService_Stop() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	client.Servers.Stop(context.Background(), "vz12345", glesys.StopServerParams{
+		Type: "reboot", // Type "soft", "hard" and "reboot" available
+	})
+}

--- a/v2/emaildomains.go
+++ b/v2/emaildomains.go
@@ -1,0 +1,344 @@
+package glesys
+
+import (
+	"context"
+	"strconv"
+	"strings"
+)
+
+// EmailDomainService provides functions to interact with the Email api
+type EmailDomainService struct {
+	client clientInterface
+}
+
+// EmailOverviewDomain represents a single email domain
+type EmailOverviewDomain struct {
+	DomainName  string `json:"domainname"`
+	DisplayName string `json:"displayname"`
+	Accounts    int    `json:"accounts"`
+	Aliases     int    `json:"aliases"`
+}
+
+// EmailOverviewSummary represents limits for the current project
+type EmailOverviewSummary struct {
+	Accounts    int `json:"accounts"`
+	MaxAccounts int `json:"maxaccounts"`
+	Aliases     int `json:"aliases"`
+	MaxAliases  int `json:"maxaliases"`
+}
+
+// EmailOverviewMeta is used to paginate the results
+type EmailOverviewMeta struct {
+	Page    int `json:"page"`
+	Total   int `json:"total"`
+	PerPage int `json:"perpage"`
+}
+
+// EmailOverview represents the overview of the accounts email setups.
+type EmailOverview struct {
+	Summary EmailOverviewSummary  `json:"summary"`
+	Domains []EmailOverviewDomain `json:"domains"`
+	Meta    EmailOverviewMeta     `json:"meta"`
+}
+
+// OverviewParams is used for filtering and/or paging on the overview endpoint.
+type OverviewParams struct {
+	Filter string `json:"filter,omitempty"`
+	Page   int    `json:"page,omitempty"`
+}
+
+// EmailGlobalQuota represents the global quota and usage
+type EmailGlobalQuota struct {
+	Usage int `json:"usage"`
+	Max   int `json:"max"`
+}
+
+// GlobalQuotaParams is used for updating the global quota for email accounts.
+type GlobalQuotaParams struct {
+	GlobalQuota int `json:"globalquota,omitempty"`
+}
+
+// EmailAccountQuota represents quota for a single email account
+type EmailAccountQuota struct {
+	Max  int    `json:"max"`
+	Unit string `json:"unit"`
+}
+
+// EmailAccount represents a single email account
+type EmailAccount struct {
+	EmailAccount         string            `json:"emailaccount"`
+	DisplayName          string            `json:"displayname"`
+	Quota                EmailAccountQuota `json:"quota"`
+	AntiSpamLevel        int               `json:"antispamlevel"`
+	AntiVirus            string            `json:"antivirus"`
+	AutoRespond          string            `json:"autorespond"`
+	AutoRespondMessage   string            `json:"autorespondmessage,omitempty"`
+	AutoRespondSaveEmail string            `json:"autorespondsaveemail"`
+	RejectSpam           string            `json:"rejectspam"`
+	Created              string            `json:"created"`
+	Modified             string            `json:"modified,omitempty"`
+}
+
+// EmailAlias represents a single email alias
+type EmailAlias struct {
+	EmailAlias  string `json:"emailalias"`
+	DisplayName string `json:"displayname"`
+	GoTo        string `json:"goto"`
+}
+
+// EmailList holds arrays of email accounts and aliases
+type EmailList struct {
+	EmailAccounts []EmailAccount `json:"emailaccounts"`
+	EmailAliases  []EmailAlias   `json:"emailaliases"`
+}
+
+// EmailAccountQuotaUsed the quota used
+type EmailAccountQuotaUsed struct {
+	Amount int    `json:"amount"`
+	Unit   string `json:"unit"`
+}
+
+// EmailQuota represents a quota object for a single email account
+type EmailQuota struct {
+	EmailAccount string                `json:"emailaccount"`
+	Used         EmailAccountQuotaUsed `json:"used"`
+	Total        EmailAccountQuota     `json:"total"`
+}
+
+// ListEmailsParams is used for filtering when listing emails for a domain.
+type ListEmailsParams struct {
+	Filter string `json:"filter,omitempty"`
+}
+
+// EditAccountParams is used for updating the different values on an email account.
+type EditAccountParams struct {
+	AntiSpamLevel      int    `json:"antispamlevel,omitempty"`
+	AntiVirus          string `json:"antivirus,omitempty"`
+	Password           string `json:"password,omitempty"`
+	AutoRespond        string `json:"autorespond,omitempty"`
+	AutoRespondMessage string `json:"autorespondmessage,omitempty"`
+	Quota              int    `json:"quota,omitempty"`
+	RejectSpam         string `json:"rejectspam,omitempty"`
+}
+
+// CreateAccountParams is used for creating new email accounts.
+type CreateAccountParams struct {
+	EmailAccount       string `json:"emailaccount"`
+	Password           string `json:"password"`
+	AntiSpamLevel      int    `json:"antispamlevel,omitempty"`
+	AntiVirus          string `json:"antivirus,omitempty"`
+	AutoRespond        string `json:"autorespond,omitempty"`
+	AutoRespondMessage string `json:"autorespondmessage,omitempty"`
+	Quota              int    `json:"quota,omitempty"`
+	RejectSpam         string `json:"rejectspam,omitempty"`
+}
+
+// EmailAliasParams is used for creating new email aliases as well as editing already existing ones.
+type EmailAliasParams struct {
+	EmailAlias string `json:"emailalias"`
+	GoTo       string `json:"goto"`
+}
+
+// EmailCostEntity represents the amount and currency or a cost
+type EmailCostEntity struct {
+	Amount   int    `json:"amount"`
+	Currency string `json:"currency"`
+}
+
+// EmailCostsEntry represents a cost object
+type EmailCostsEntry struct {
+	Amount int             `json:"amount"`
+	Cost   EmailCostEntity `json:"cost"`
+}
+
+// EmailQuotaPricelist is the pricelist for quota options
+type EmailQuotaPricelist struct {
+	Amount     string `json:"amount"`
+	Currency   string `json:"currency"`
+	Unit       string `json:"unit"`
+	FreeAmount int    `json:"freeamount"`
+}
+
+// EmailAccountsPricelist is the pricelist for email
+type EmailAccountsPricelist struct {
+	Amount     int    `json:"amount"`
+	Currency   string `json:"currency"`
+	Unit       string `json:"unit"`
+	FreeAmount int    `json:"freeamount"`
+}
+
+// EmailCostsContainer contains quota and accounts for email costs
+type EmailCostsContainer struct {
+	Quota    EmailCostsEntry `json:"quota"`
+	Accounts EmailCostsEntry `json:"accounts"`
+}
+
+// EmailPricelistContainer contains quota and accounts for pricelist
+type EmailPricelistContainer struct {
+	Quota    EmailQuotaPricelist    `json:"quota"`
+	Accounts EmailAccountsPricelist `json:"accounts"`
+}
+
+// EmailCosts represents a email cost object
+type EmailCosts struct {
+	Costs     EmailCostsContainer     `json:"costs"`
+	PriceList EmailPricelistContainer `json:"pricelist"`
+}
+
+// Overview fetches a summary of the email accounts and domains on the account.
+func (em *EmailDomainService) Overview(context context.Context, params OverviewParams) (*EmailOverview, error) {
+
+	// String builder for creating the suffix based on the page and/or filter.
+	var suffixbuilder strings.Builder
+
+	// Only add suffix paths to the builder if the struct fields does not contain the default value.
+	if params.Filter != "" {
+		suffixbuilder.WriteString("/filter/" + params.Filter)
+	}
+
+	if params.Page != 0 {
+		suffixbuilder.WriteString("/page/" + strconv.Itoa(params.Page))
+	}
+
+	// Extract the string from the builder.
+	// If nothing has been added then this will be an empty string.
+	pathsuffix := suffixbuilder.String()
+
+	data := struct {
+		Response struct {
+			Overview EmailOverview
+		}
+	}{}
+
+	// Append the suffix to the endpoint
+	err := em.client.get(context, "email/overview"+pathsuffix, &data)
+	return &data.Response.Overview, err
+}
+
+// GlobalQuota enables the user to set and get the global quota.
+func (em *EmailDomainService) GlobalQuota(context context.Context, params GlobalQuotaParams) (*EmailGlobalQuota, error) {
+	data := struct {
+		Response struct {
+			GlobalQuota EmailGlobalQuota
+		}
+	}{}
+
+	err := em.client.post(context, "email/globalquota", &data, struct {
+		GlobalQuotaParams
+	}{params})
+
+	return &data.Response.GlobalQuota, err
+}
+
+// List Gets a list of all accounts and aliases of a domain with full details.
+func (em *EmailDomainService) List(context context.Context, domain string, params ListEmailsParams) (*EmailList, error) {
+	data := struct {
+		Response struct {
+			List EmailList
+		}
+	}{}
+
+	err := em.client.post(context, "email/list", &data, struct {
+		ListEmailsParams
+		DomainName string `json:"domainname"`
+	}{params, domain})
+
+	return &data.Response.List, err
+}
+
+// EditAccount allows you to Edit an email account's parameters.
+func (em *EmailDomainService) EditAccount(context context.Context, emailAccount string, params EditAccountParams) (*EmailAccount, error) {
+	data := struct {
+		Response struct {
+			EmailAccount EmailAccount
+		}
+	}{}
+
+	err := em.client.post(context, "email/editaccount", &data, struct {
+		EditAccountParams
+		EmailAccount string `json:"emailaccount"`
+	}{params, emailAccount})
+
+	return &data.Response.EmailAccount, err
+}
+
+// Delete allows you to remove an email account or alias.
+func (em *EmailDomainService) Delete(context context.Context, email string) error {
+	return em.client.post(context, "email/delete", nil, struct {
+		Email string `json:"email"`
+	}{email})
+}
+
+// CreateAccount allows you to create an email account.
+func (em *EmailDomainService) CreateAccount(context context.Context, params CreateAccountParams) (*EmailAccount, error) {
+	data := struct {
+		Response struct {
+			EmailAccount EmailAccount
+		}
+	}{}
+
+	err := em.client.post(context, "email/createaccount", &data, struct {
+		CreateAccountParams
+	}{params})
+
+	return &data.Response.EmailAccount, err
+}
+
+// Quota returns the used and total quota for an email account.
+func (em *EmailDomainService) Quota(context context.Context, emailaccount string) (*EmailQuota, error) {
+	data := struct {
+		Response struct {
+			Quota EmailQuota
+		}
+	}{}
+
+	err := em.client.post(context, "email/quota", &data, struct {
+		EmailAccount string `json:"emailaccount"`
+	}{emailaccount})
+
+	return &data.Response.Quota, err
+}
+
+// CreateAlias sets up a new alias.
+func (em *EmailDomainService) CreateAlias(context context.Context, params EmailAliasParams) (*EmailAlias, error) {
+	data := struct {
+		Response struct {
+			Alias EmailAlias
+		}
+	}{}
+
+	err := em.client.post(context, "email/createalias", &data, struct {
+		EmailAliasParams
+	}{params})
+
+	return &data.Response.Alias, err
+}
+
+// EditAlias updates an already existing alias.
+func (em *EmailDomainService) EditAlias(context context.Context, params EmailAliasParams) (*EmailAlias, error) {
+	data := struct {
+		Response struct {
+			Alias EmailAlias
+		}
+	}{}
+
+	err := em.client.post(context, "email/editalias", &data, struct {
+		EmailAliasParams
+	}{params})
+
+	return &data.Response.Alias, err
+}
+
+// Costs returns the email related costs and the current pricelist.
+func (em *EmailDomainService) Costs(context context.Context) (*EmailCosts, error) {
+	data := struct {
+		Response struct {
+			Costs     EmailCostsContainer
+			PriceList EmailPricelistContainer
+		}
+	}{}
+
+	err := em.client.get(context, "email/costs", &data)
+
+	return &EmailCosts{Costs: data.Response.Costs, PriceList: data.Response.PriceList}, err
+}

--- a/v2/emaildomains_test.go
+++ b/v2/emaildomains_test.go
@@ -1,0 +1,279 @@
+package glesys
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmailsOverview(t *testing.T) {
+	c := &mockClient{body: `{"response":{"overview":{"summary":{"accounts":0,"maxaccounts":2000,"aliases":0,"maxaliases":10000},"domains":[{"domainname":"example.com","displayname":"example.com","accounts":0,"aliases":0}],"meta":{"page":1,"total":1,"perpage":1}}}}`}
+	s := EmailDomainService{client: c}
+
+	emailoverview, _ := s.Overview(context.Background(), OverviewParams{})
+	emaildomains := &emailoverview.Domains
+	emailsummary := &emailoverview.Summary
+	emailmeta := &emailoverview.Meta
+
+	assert.Equal(t, "GET", c.lastMethod, "method used is correct")
+	assert.Equal(t, "email/overview", c.lastPath, "path used is correct")
+	assert.Equal(t, "example.com", (*emaildomains)[0].DomainName, "domainname is correct")
+	assert.Equal(t, "example.com", (*emaildomains)[0].DisplayName, "displayname is correct")
+	assert.Equal(t, 0, (*emaildomains)[0].Accounts, "number of accounts is correct")
+	assert.Equal(t, 0, (*emaildomains)[0].Aliases, "number of aliases is correct")
+	assert.Equal(t, 0, (*emailsummary).Accounts, "number of summary accounts is correct")
+	assert.Equal(t, 2000, (*emailsummary).MaxAccounts, "number of summary maxaccounts is correct")
+	assert.Equal(t, 0, (*emailsummary).Aliases, "number of summary aliases is correct")
+	assert.Equal(t, 10000, (*emailsummary).MaxAliases, "number of summary maxaliases is correct")
+	assert.Equal(t, 1, (*emailmeta).Page, "Page number is correct")
+	assert.Equal(t, 1, (*emailmeta).Total, "Total number is correct")
+	assert.Equal(t, 1, (*emailmeta).PerPage, "Per page number is correct")
+}
+
+func TestEmailsOverviewWithFilterParameter(t *testing.T) {
+	c := &mockClient{body: `{"response":{"overview":{"summary":{"accounts":0,"maxaccounts":2000,"aliases":0,"maxaliases":10000},"domains":[{"domainname":"example.com","displayname":"example.com","accounts":0,"aliases":0}],"meta":{"page":1,"total":1,"perpage":1}}}}`}
+	s := EmailDomainService{client: c}
+
+	emailoverview, _ := s.Overview(context.Background(), OverviewParams{Filter: "example.com"})
+	emaildomains := &emailoverview.Domains
+	emailsummary := &emailoverview.Summary
+	emailmeta := &emailoverview.Meta
+
+	assert.Equal(t, "GET", c.lastMethod, "method used is correct")
+	assert.Equal(t, "email/overview/filter/example.com", c.lastPath, "path used is correct")
+	assert.Equal(t, "example.com", (*emaildomains)[0].DomainName, "domainname is correct")
+	assert.Equal(t, "example.com", (*emaildomains)[0].DisplayName, "displayname is correct")
+	assert.Equal(t, 0, (*emaildomains)[0].Accounts, "number of accounts is correct")
+	assert.Equal(t, 0, (*emaildomains)[0].Aliases, "number of aliases is correct")
+	assert.Equal(t, 0, (*emailsummary).Accounts, "number of summary accounts is correct")
+	assert.Equal(t, 2000, (*emailsummary).MaxAccounts, "number of summary maxaccounts is correct")
+	assert.Equal(t, 0, (*emailsummary).Aliases, "number of summary aliases is correct")
+	assert.Equal(t, 10000, (*emailsummary).MaxAliases, "number of summary maxaliases is correct")
+	assert.Equal(t, 1, (*emailmeta).Page, "Page number is correct")
+	assert.Equal(t, 1, (*emailmeta).Total, "Total number is correct")
+	assert.Equal(t, 1, (*emailmeta).PerPage, "Per page number is correct")
+}
+
+func TestEmailsOverviewWithPageParameter(t *testing.T) {
+	c := &mockClient{body: `{"response":{"overview":{"summary":{"accounts":0,"maxaccounts":2000,"aliases":0,"maxaliases":10000},"domains":[{"domainname":"example.com","displayname":"example.com","accounts":0,"aliases":0}],"meta":{"page":2,"total":31,"perpage":30}}}}`}
+	s := EmailDomainService{client: c}
+	emailoverview, _ := s.Overview(context.Background(), OverviewParams{Page: 2})
+	emaildomains := &emailoverview.Domains
+	emailsummary := &emailoverview.Summary
+	emailmeta := &emailoverview.Meta
+
+	assert.Equal(t, "GET", c.lastMethod, "method used is correct")
+	assert.Equal(t, "email/overview/page/2", c.lastPath, "path used is correct")
+	assert.Equal(t, "example.com", (*emaildomains)[0].DomainName, "domainname is correct")
+	assert.Equal(t, "example.com", (*emaildomains)[0].DisplayName, "displayname is correct")
+	assert.Equal(t, 0, (*emaildomains)[0].Accounts, "number of accounts is correct")
+	assert.Equal(t, 0, (*emaildomains)[0].Aliases, "number of aliases is correct")
+	assert.Equal(t, 0, (*emailsummary).Accounts, "number of summary accounts is correct")
+	assert.Equal(t, 2000, (*emailsummary).MaxAccounts, "number of summary maxaccounts is correct")
+	assert.Equal(t, 0, (*emailsummary).Aliases, "number of summary aliases is correct")
+	assert.Equal(t, 10000, (*emailsummary).MaxAliases, "number of summary maxaliases is correct")
+	assert.Equal(t, 2, (*emailmeta).Page, "Page number is correct")
+	assert.Equal(t, 31, (*emailmeta).Total, "Total number is correct")
+	assert.Equal(t, 30, (*emailmeta).PerPage, "Per page number is correct")
+}
+
+func TestEmailsOverviewWithFilterAndPageParameter(t *testing.T) {
+	c := &mockClient{body: `{"response":{"overview":{"summary":{"accounts":0,"maxaccounts":2000,"aliases":0,"maxaliases":10000},"domains":[{"domainname":"example.com","displayname":"example.com","accounts":0,"aliases":0}],"meta":{"page":1,"total":1,"perpage":1}}}}`}
+	s := EmailDomainService{client: c}
+
+	emailoverview, _ := s.Overview(context.Background(), OverviewParams{Filter: "example.com", Page: 1})
+	emaildomains := &emailoverview.Domains
+	emailsummary := &emailoverview.Summary
+	emailmeta := &emailoverview.Meta
+
+	assert.Equal(t, "GET", c.lastMethod, "method used is correct")
+	assert.Equal(t, "email/overview/filter/example.com/page/1", c.lastPath, "path used is correct")
+	assert.Equal(t, "example.com", (*emaildomains)[0].DomainName, "domainname is correct")
+	assert.Equal(t, "example.com", (*emaildomains)[0].DisplayName, "displayname is correct")
+	assert.Equal(t, 0, (*emaildomains)[0].Accounts, "number of accounts is correct")
+	assert.Equal(t, 0, (*emaildomains)[0].Aliases, "number of aliases is correct")
+	assert.Equal(t, 0, (*emailsummary).Accounts, "number of summary accounts is correct")
+	assert.Equal(t, 2000, (*emailsummary).MaxAccounts, "number of summary maxaccounts is correct")
+	assert.Equal(t, 0, (*emailsummary).Aliases, "number of summary aliases is correct")
+	assert.Equal(t, 10000, (*emailsummary).MaxAliases, "number of summary maxaliases is correct")
+	assert.Equal(t, 1, (*emailmeta).Page, "Page number is correct")
+	assert.Equal(t, 1, (*emailmeta).Total, "Total number is correct")
+	assert.Equal(t, 1, (*emailmeta).PerPage, "Per page number is correct")
+}
+
+func TestEmailsGlobalQuotaWithoutNewParam(t *testing.T) {
+	c := &mockClient{body: `{"response":{"globalquota":{"usage":0,"max":10240}}}`}
+	s := EmailDomainService{client: c}
+
+	emailglobalquota, _ := s.GlobalQuota(context.Background(), GlobalQuotaParams{})
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "email/globalquota", c.lastPath, "path used is correct")
+	assert.Equal(t, 0, emailglobalquota.Usage, "usage number is correct")
+	assert.Equal(t, 10240, emailglobalquota.Max, "max number is correct")
+}
+
+func TestEmailsGlobalQuotaWithNewParam(t *testing.T) {
+	c := &mockClient{body: `{"response":{"globalquota":{"usage":0,"max":20480}}}`}
+	s := EmailDomainService{client: c}
+
+	emailglobalquota, _ := s.GlobalQuota(context.Background(), GlobalQuotaParams{GlobalQuota: 20480})
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "email/globalquota", c.lastPath, "path used is correct")
+	assert.Equal(t, 0, emailglobalquota.Usage, "usage number is correct")
+	assert.Equal(t, 20480, emailglobalquota.Max, "max number is correct")
+}
+
+func TestEmailsList(t *testing.T) {
+	c := &mockClient{body: `{"response":{"list":{"emailaccounts":[{"emailaccount":"user@example.com","displayname":"user@example.com","quota":{"max":200,"unit":"MB"},"antispamlevel":3,"antivirus":"yes","autorespond":"yes","autorespondmessage":"This is not the account you are looking for.\n\nMove along, move along.","autorespondsaveemail":"yes","rejectspam":"no","created":"2019-10-26T13:07:13+02:00","modified":"2019-10-26T15:38:51+02:00"}],"emailaliases":[{"emailalias":"alias@example.com","displayname":"alias@example.com","goto":"user@example.com"}]}}}`}
+	s := EmailDomainService{client: c}
+
+	emaillist, _ := s.List(context.Background(), "example.com", ListEmailsParams{})
+	emailaccounts := &emaillist.EmailAccounts
+	emailaliases := &emaillist.EmailAliases
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "email/list", c.lastPath, "path used is correct")
+
+	assert.Equal(t, "user@example.com", (*emailaccounts)[0].EmailAccount, "emailaccount is correct")
+	assert.Equal(t, "user@example.com", (*emailaccounts)[0].DisplayName, "displayname is correct")
+	assert.Equal(t, 200, (*emailaccounts)[0].Quota.Max, "quota.max is correct")
+	assert.Equal(t, "MB", (*emailaccounts)[0].Quota.Unit, "quota.unit is correct")
+	assert.Equal(t, 3, (*emailaccounts)[0].AntiSpamLevel, "antispamlevel is correct")
+	assert.Equal(t, "yes", (*emailaccounts)[0].AntiVirus, "antivirus is correct")
+	assert.Equal(t, "yes", (*emailaccounts)[0].AutoRespond, "autorespond is correct")
+	assert.Equal(t, "This is not the account you are looking for.\n\nMove along, move along.", (*emailaccounts)[0].AutoRespondMessage, "autorespondmessage is correct")
+	assert.Equal(t, "yes", (*emailaccounts)[0].AutoRespondSaveEmail, "autorespondsaveemail is correct")
+	assert.Equal(t, "no", (*emailaccounts)[0].RejectSpam, "rejectspam is correct")
+	assert.Equal(t, "2019-10-26T13:07:13+02:00", (*emailaccounts)[0].Created, "created is correct")
+	assert.Equal(t, "2019-10-26T15:38:51+02:00", (*emailaccounts)[0].Modified, "modified is correct")
+
+	assert.Equal(t, "alias@example.com", (*emailaliases)[0].EmailAlias, "emailalias is correct")
+	assert.Equal(t, "alias@example.com", (*emailaliases)[0].DisplayName, "displayname is correct")
+	assert.Equal(t, "user@example.com", (*emailaliases)[0].GoTo, "goto is correct")
+}
+
+func TestEmailEditAccount(t *testing.T) {
+	c := &mockClient{body: `{"response":{"emailaccount":{"emailaccount":"user@example.com","displayname":"user@example.com","quota":{"max":200,"unit":"MB"},"antispamlevel":3,"antivirus":"yes","autorespond":"yes","autorespondmessage":"This is not the account you are looking for.\n\nMove along, move along.","autorespondsaveemail":"yes","rejectspam":"no","created":"2019-10-26T13:07:13+02:00","modified":"2019-11-10T22:09:14+01:00"}}}`}
+	s := EmailDomainService{client: c}
+
+	editaccount, _ := s.EditAccount(context.Background(), "user@example.com", EditAccountParams{Quota: 200})
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "email/editaccount", c.lastPath, "path used is correct")
+	assert.Equal(t, "user@example.com", editaccount.EmailAccount, "emailaccount is correct")
+	assert.Equal(t, "user@example.com", editaccount.DisplayName, "displayname is correct")
+	assert.Equal(t, 200, editaccount.Quota.Max, "quota.max is correct")
+	assert.Equal(t, "MB", editaccount.Quota.Unit, "quota.unit is correct")
+	assert.Equal(t, 3, editaccount.AntiSpamLevel, "antispamlevel is correct")
+	assert.Equal(t, "yes", editaccount.AntiVirus, "antivirus is correct")
+	assert.Equal(t, "yes", editaccount.AutoRespond, "autorespond is correct")
+	assert.Equal(t, "This is not the account you are looking for.\n\nMove along, move along.", editaccount.AutoRespondMessage, "autorespondmessage is correct")
+	assert.Equal(t, "yes", editaccount.AutoRespondSaveEmail, "autorespondsaveemail is correct")
+	assert.Equal(t, "no", editaccount.RejectSpam, "rejectspam is correct")
+	assert.Equal(t, "2019-10-26T13:07:13+02:00", editaccount.Created, "created is correct")
+	assert.Equal(t, "2019-11-10T22:09:14+01:00", editaccount.Modified, "modified is correct")
+}
+
+func TestEmailDelete(t *testing.T) {
+	c := &mockClient{body: `{"response": {}}`}
+	s := EmailDomainService{client: c}
+
+	s.Delete(context.Background(), "user@example.com")
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "email/delete", c.lastPath, "path used is correct")
+}
+
+func TestCreateAccount(t *testing.T) {
+	c := &mockClient{body: `{"response":{"emailaccount":{"emailaccount":"new_user@example.com","displayname":"new_user@example.com","quota":{"max":200,"unit":"MB"},"antispamlevel":3,"antivirus":"yes","autorespond":"no","autorespondmessage":null,"autorespondsaveemail":"yes","rejectspam":"no","created":"2019-11-29T21:31:28+01:00","modified":null}}}`}
+
+	s := EmailDomainService{client: c}
+
+	createaccount, _ := s.CreateAccount(context.Background(), CreateAccountParams{EmailAccount: "new_user@example.com", Password: "SuperSecretPassword"})
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "email/createaccount", c.lastPath, "path used is correct")
+	assert.Equal(t, "new_user@example.com", createaccount.EmailAccount, "emailaccount is correct")
+	assert.Equal(t, "new_user@example.com", createaccount.DisplayName, "displayname is correct")
+	assert.Equal(t, 200, createaccount.Quota.Max, "quota.max is correct")
+	assert.Equal(t, "MB", createaccount.Quota.Unit, "quota.unit is correct")
+	assert.Equal(t, 3, createaccount.AntiSpamLevel, "antispamlevel is correct")
+	assert.Equal(t, "yes", createaccount.AntiVirus, "antivirus is correct")
+	assert.Equal(t, "no", createaccount.AutoRespond, "autorespond is correct")
+	assert.Equal(t, "", createaccount.AutoRespondMessage, "autorespondmessage is correct")
+	assert.Equal(t, "yes", createaccount.AutoRespondSaveEmail, "autorespondsaveemail is correct")
+	assert.Equal(t, "no", createaccount.RejectSpam, "rejectspam is correct")
+	assert.Equal(t, "2019-11-29T21:31:28+01:00", createaccount.Created, "created is correct")
+	assert.Equal(t, "", createaccount.Modified, "modified is correct")
+}
+
+func TestQuota(t *testing.T) {
+	c := &mockClient{body: `{"response":{"quota":{"emailaccount":"user@example.com","used":{"amount":0,"unit":"MB"},"total":{"max":400,"unit":"MB"}}}}`}
+
+	s := EmailDomainService{client: c}
+
+	quota, _ := s.Quota(context.Background(), "user@example.com")
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "email/quota", c.lastPath, "path used is correct")
+	assert.Equal(t, "user@example.com", quota.EmailAccount, "emailaccount is correct")
+	assert.Equal(t, 0, quota.Used.Amount, "used amount is correct")
+	assert.Equal(t, "MB", quota.Used.Unit, "used unit is correct")
+	assert.Equal(t, 400, quota.Total.Max, "total max is correct")
+	assert.Equal(t, "MB", quota.Total.Unit, "total unit is correct")
+}
+
+func TestCreateAlias(t *testing.T) {
+	c := &mockClient{body: `{"response":{"alias":{"emailalias":"alias@example.com","displayname":"alias@example.com","goto":"user@example.com"}}}`}
+
+	s := EmailDomainService{client: c}
+
+	alias, _ := s.CreateAlias(context.Background(), EmailAliasParams{EmailAlias: "alias@example.com", GoTo: "user@example.com"})
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "email/createalias", c.lastPath, "path used is correct")
+	assert.Equal(t, "alias@example.com", alias.EmailAlias, "emailalias is correct")
+	assert.Equal(t, "alias@example.com", alias.DisplayName, "displayname is correct")
+	assert.Equal(t, "user@example.com", alias.GoTo, "goto is correct")
+}
+
+func TestEditAlias(t *testing.T) {
+	c := &mockClient{body: `{"response":{"alias":{"emailalias":"alias@example.com","displayname":"alias@example.com","goto":"anotheruser@example.com"}}}`}
+
+	s := EmailDomainService{client: c}
+
+	alias, _ := s.CreateAlias(context.Background(), EmailAliasParams{EmailAlias: "alias@example.com", GoTo: "user@example.com"})
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "email/createalias", c.lastPath, "path used is correct")
+	assert.Equal(t, "alias@example.com", alias.EmailAlias, "emailalias is correct")
+	assert.Equal(t, "alias@example.com", alias.DisplayName, "displayname is correct")
+	assert.Equal(t, "anotheruser@example.com", alias.GoTo, "goto is correct")
+}
+
+func TestCosts(t *testing.T) {
+	c := &mockClient{body: `{"response":{"costs":{"quota":{"amount":10,"cost":{"amount":0,"currency":"SEK"}},"accounts":{"amount":3,"cost":{"amount":0,"currency":"SEK"}}},"pricelist":{"quota":{"amount":"1.00","currency":"SEK","unit":"GB","freeamount":10},"accounts":{"amount":50,"currency":"SEK","unit":"accounts","freeamount":50}}}}`}
+
+	s := EmailDomainService{client: c}
+
+	costs, _ := s.Costs(context.Background())
+	assert.Equal(t, "GET", c.lastMethod, "method used is correct")
+	assert.Equal(t, "email/costs", c.lastPath, "path used is correct")
+	assert.Equal(t, 10, costs.Costs.Quota.Amount, "costs.quota.amount is correct")
+	assert.Equal(t, 0, costs.Costs.Quota.Cost.Amount, "costs.quota.cost.amount is correct")
+	assert.Equal(t, "SEK", costs.Costs.Quota.Cost.Currency, "costs.quota.cost.currency is correct")
+	assert.Equal(t, 3, costs.Costs.Accounts.Amount, "costs.accounts.amount is correct")
+	assert.Equal(t, 0, costs.Costs.Accounts.Cost.Amount, "costs.accounts.cost.amount is correct")
+	assert.Equal(t, "SEK", costs.Costs.Accounts.Cost.Currency, "costs.accounts.cost.currency is correct")
+	assert.Equal(t, "1.00", costs.PriceList.Quota.Amount, "pricelist.quota.amount is correct")
+	assert.Equal(t, "SEK", costs.PriceList.Quota.Currency, "pricelist.quota.currency is correct")
+	assert.Equal(t, "GB", costs.PriceList.Quota.Unit, "pricelist.quota.unit is correct")
+	assert.Equal(t, 10, costs.PriceList.Quota.FreeAmount, "pricelist.quota.freeamount is correct")
+	assert.Equal(t, 50, costs.PriceList.Accounts.Amount, "pricelist.accounts.amount is correct")
+	assert.Equal(t, "SEK", costs.PriceList.Accounts.Currency, "pricelist.accounts.currency is correct")
+	assert.Equal(t, "accounts", costs.PriceList.Accounts.Unit, "pricelist.accounts.unit is correct")
+	assert.Equal(t, 50, costs.PriceList.Accounts.FreeAmount, "pricelist.accounts.freeamount is correct")
+}

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,0 +1,12 @@
+module github.com/glesys/glesys-go/v2
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/imdario/mergo v0.3.7
+	github.com/kr/pretty v0.2.0 // indirect
+	github.com/stretchr/testify v1.3.0
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
+)
+
+go 1.13

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -1,0 +1,16 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
+github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/v2/ips.go
+++ b/v2/ips.go
@@ -1,0 +1,144 @@
+package glesys
+
+import (
+	"context"
+	"net"
+	"strings"
+)
+
+// IPService provides functions to interact with IP addresses
+type IPService struct {
+	client clientInterface
+}
+
+// IP represents an IP address
+type IP struct {
+	Address         string   `json:"ipaddress"`
+	Broadcast       string   `json:"broadcast,omitempty"`
+	Cost            IPCost   `json:"cost,omitempty"`
+	DataCenter      string   `json:"datacenter,omitempty"`
+	Gateway         string   `json:"gateway,omitempty"`
+	LockedToAccount string   `json:"lockedtoaccount,omitempty"`
+	NameServers     []string `json:"nameservers,omitempty"`
+	Netmask         string   `json:"netmask,omitempty"`
+	Platforms       []string `json:"platforms,omitempty"`
+	Platform        string   `json:"platform,omitempty"`
+	PTR             string   `json:"ptr,omitempty"`
+	Reserved        string   `json:"reserved,omitempty"`
+	ServerID        string   `json:"serverid,omitempty"`
+	Version         int      `json:"ipversion,omitempty"`
+}
+
+// AvailableIPsParams is used to filter results when listing available IP addresses
+type AvailableIPsParams struct {
+	DataCenter string `json:"datacenter"`
+	Platform   string `json:"platform"`
+	Version    int    `json:"ipversion"`
+}
+
+// IPCost is used to show cost details for a IP address
+type IPCost struct {
+	Amount     int    `json:"amount"`
+	Currency   string `json:"currency"`
+	TimePeriod string `json:"timeperiod"`
+}
+
+// Available returns a list of IP addresses available for reservation
+func (s *IPService) Available(context context.Context, params AvailableIPsParams) (*[]IP, error) {
+	data := struct {
+		Response struct {
+			IPList struct {
+				IPAddresses []string
+			}
+		}
+	}{}
+
+	err := s.client.post(context, "ip/listfree", &data, params)
+	if err != nil {
+		return nil, err
+	}
+
+	// Because, inconsistencies...
+	ips := make([]IP, 0)
+	for _, address := range data.Response.IPList.IPAddresses {
+		ips = append(ips, IP{Address: address})
+	}
+	return &ips, nil
+}
+
+// Details about an IP address
+func (s *IPService) Details(context context.Context, ipAddress string) (*IP, error) {
+	data := struct {
+		Response struct {
+			Details IP
+		}
+	}{}
+	err := s.client.post(context, "ip/details", &data, map[string]string{"ipaddress": ipAddress})
+	return &data.Response.Details, err
+}
+
+// IsIPv4 verify that ip is IPv4
+func (ip *IP) IsIPv4() bool {
+	netAddr := net.ParseIP(ip.Address)
+	return netAddr != nil && strings.Contains(ip.Address, ".")
+}
+
+// IsIPv6 verify that ip is IPv6
+func (ip *IP) IsIPv6() bool {
+	netAddr := net.ParseIP(ip.Address)
+	return netAddr != nil && strings.Contains(ip.Address, ":")
+}
+
+// Release releases a reserved IP address
+func (s *IPService) Release(context context.Context, ipAddress string) error {
+	return s.client.post(context, "ip/release", nil, map[string]string{"ipaddress": ipAddress})
+}
+
+// Reserve reserves an available IP address
+func (s *IPService) Reserve(context context.Context, ipAddress string) (*IP, error) {
+	data := struct {
+		Response struct {
+			Details IP
+		}
+	}{}
+	err := s.client.post(context, "ip/take", &data, map[string]string{"ipaddress": ipAddress})
+	return &data.Response.Details, err
+}
+
+// Reserved returns a list of reserved IP addresses
+func (s *IPService) Reserved(context context.Context) (*[]IP, error) {
+	data := struct {
+		Response struct {
+			IPList []IP
+		}
+	}{}
+	err := s.client.get(context, "ip/listown", &data)
+	return &data.Response.IPList, err
+}
+
+// SetPTR sets PTR for an IP address
+func (s *IPService) SetPTR(context context.Context, ipAddress string, ptrdata string) (*IP, error) {
+	data := struct {
+		Response struct {
+			Details IP
+		}
+	}{}
+	err := s.client.post(context, "ip/setptr", &data, struct {
+		Address string `json:"ipaddress"`
+		PTR     string `json:"data"`
+	}{ipAddress, ptrdata})
+	return &data.Response.Details, err
+}
+
+// ResetPTR resets PTR for an IP address
+func (s *IPService) ResetPTR(context context.Context, ipAddress string) (*IP, error) {
+	data := struct {
+		Response struct {
+			Details IP
+		}
+	}{}
+	err := s.client.post(context, "ip/resetptr", &data, struct {
+		Address string `json:"ipaddress"`
+	}{ipAddress})
+	return &data.Response.Details, err
+}

--- a/v2/ips_test.go
+++ b/v2/ips_test.go
@@ -1,0 +1,133 @@
+package glesys
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIPsAvailable(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "iplist": { "ipaddresses": ["127.0.0.1"] }} }`}
+	s := IPService{client: c}
+
+	ips, _ := s.Available(context.Background(), AvailableIPsParams{})
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "ip/listfree", c.lastPath, "path used is correct")
+	assert.Equal(t, "127.0.0.1", (*ips)[0].Address, "one ip was returned")
+}
+
+func TestIPsIsIPv4(t *testing.T) {
+	var ips = []IP{
+		{Address: "127.0.0.1"},
+		{Address: "300.0.0.1"},
+		{Address: "2001:db8::1"},
+	}
+
+	assert.Equal(t, true, ips[0].IsIPv4(), "ip is version 4")
+	assert.Equal(t, false, ips[1].IsIPv4(), "ip is not version 4")
+	assert.Equal(t, false, ips[2].IsIPv4(), "ip is not version 4")
+}
+
+func TestIPsIsIPv6(t *testing.T) {
+	var ips = []IP{
+		{Address: "2001:db8::1"},
+		{Address: "::1"},
+		{Address: "300.0.0.1"},
+		{Address: "::2001::1"},
+	}
+
+	assert.Equal(t, true, ips[0].IsIPv6(), "ip is version 6")
+	assert.Equal(t, true, ips[1].IsIPv6(), "ip is version 6")
+	assert.Equal(t, false, ips[2].IsIPv6(), "ip is not version 6")
+	assert.Equal(t, false, ips[3].IsIPv6(), "ip is not version 6")
+}
+
+func TestIPsDetails(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "details": { "ipaddress": "127.0.0.1",
+		"netmask": "None", "broadcast": "None", "gateway": "None", "nameservers": ["127.255.255.1"],
+		"platform": "OpenVZ", "platforms": ["OpenVZ"],
+		"cost": {"amount":1, "currency": "SEK", "timeperiod": "month"},
+		"datacenter": "Falkenberg", "ipversion": 4, "serverid": "vz123456", "reserved": "yes",
+		"lockedtoaccount": "no", "ptr": "1.0.0.127-static.example.com."} } }`}
+	s := IPService{client: c}
+
+	ip, _ := s.Details(context.Background(), "127.0.0.1")
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "ip/details", c.lastPath, "path used is correct")
+	assert.Equal(t, "127.0.0.1", (*ip).Address, "one ip was returned")
+	assert.Equal(t, "OpenVZ", (*ip).Platform, "platform is correct")
+	assert.Equal(t, "Falkenberg", (*ip).DataCenter, "datacenter is correct")
+	assert.Equal(t, "1.0.0.127-static.example.com.", (*ip).PTR, "ptr is correct")
+	assert.Equal(t, 1, (*ip).Cost.Amount, "cost amount is correct")
+}
+
+func TestIPsReserved(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "iplist": [{ "ipaddress": "127.0.0.1"},
+		{ "ipaddress": "2001:db8::1"}] } }`}
+	s := IPService{client: c}
+
+	ips, _ := s.Reserved(context.Background())
+
+	assert.Equal(t, "GET", c.lastMethod, "method used is correct")
+	assert.Equal(t, "ip/listown", c.lastPath, "path used is correct")
+	assert.Equal(t, "127.0.0.1", (*ips)[0].Address, "one ip was returned")
+	assert.Equal(t, "2001:db8::1", (*ips)[1].Address, "one ip was returned")
+}
+
+func TestIPsReserve(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "details": { "ipaddress": "127.0.0.1" } } }`}
+	s := IPService{client: c}
+
+	ip, _ := s.Reserve(context.Background(), "127.0.0.1")
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "ip/take", c.lastPath, "path used is correct")
+	assert.Equal(t, "127.0.0.1", (*ip).Address, "one ip was returned")
+}
+
+func TestIPService_Release(t *testing.T) {
+	c := &mockClient{}
+	s := IPService{client: c}
+
+	s.Release(context.Background(), "127.0.0.1")
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "ip/release", c.lastPath, "path used is correct")
+}
+
+func TestIPs_SetPTR(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "details": { "ipaddress": "127.0.0.1",
+		"netmask": "None", "broadcast": "None", "gateway": "None", "nameservers": ["127.255.255.1"],
+		"platform": "OpenVZ", "platforms": ["OpenVZ"],
+		"cost": {"amount":1, "currency": "SEK", "timeperiod": "month"},
+		"datacenter": "Falkenberg", "ipversion": 4, "serverid": "vz123456", "reserved": "yes",
+		"lockedtoaccount": "no", "ptr": "ptr.parker.example.com."} } }`}
+	s := IPService{client: c}
+
+	ip, _ := s.SetPTR(context.Background(), "127.0.0.1", "ptr.parker.example.com.")
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "ip/setptr", c.lastPath, "path used is correct")
+	assert.Equal(t, "127.0.0.1", (*ip).Address, "one ip was returned")
+	assert.Equal(t, "ptr.parker.example.com.", (*ip).PTR, "ptr is correct")
+}
+
+func TestIPs_ResetPTR(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "details": { "ipaddress": "127.0.0.1",
+		"netmask": "None", "broadcast": "None", "gateway": "None", "nameservers": ["127.255.255.1"],
+		"platform": "OpenVZ", "platforms": ["OpenVZ"],
+		"cost": {"amount":1, "currency": "SEK", "timeperiod": "month"},
+		"datacenter": "Falkenberg", "ipversion": 4, "serverid": "vz123456", "reserved": "yes",
+		"lockedtoaccount": "no", "ptr": "1-0-0-127-static.glesys.net."} } }`}
+	s := IPService{client: c}
+
+	ip, _ := s.ResetPTR(context.Background(), "127.0.0.1")
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "ip/resetptr", c.lastPath, "path used is correct")
+	assert.Equal(t, "127.0.0.1", (*ip).Address, "one ip was returned")
+	assert.Equal(t, "1-0-0-127-static.glesys.net.", (*ip).PTR, "ptr is correct")
+}

--- a/v2/loadbalancers.go
+++ b/v2/loadbalancers.go
@@ -1,0 +1,423 @@
+package glesys
+
+import (
+	"context"
+	"fmt"
+)
+
+// LoadBalancerService provides functions to interact with LoadBalancers
+type LoadBalancerService struct {
+	client clientInterface
+}
+
+// LoadBalancer represents a loadbalancer
+type LoadBalancer struct {
+	DataCenter string `json:"datacenter"`
+	ID         string `json:"loadbalancerid"`
+	Name       string `json:"name"`
+}
+
+// LoadBalancerDetails represents the detailed version of a load balancer
+type LoadBalancerDetails struct {
+	BackendsList  []LoadBalancerBackend  `json:"backends"`
+	Blacklists    []string               `json:"blacklist"`
+	DataCenter    string                 `json:"datacenter"`
+	FrontendsList []LoadBalancerFrontend `json:"frontends"`
+	ID            string                 `json:"loadbalancerid"`
+	IPList        []LoadBalancerIP       `json:"ipaddress"`
+	Name          string                 `json:"name"`
+}
+
+// LoadBalancerIP represents a single load balancer IP
+type LoadBalancerIP struct {
+	Address         string `json:"ipaddress"`
+	Cost            int    `json:"cost"`
+	LockedToAccount bool   `json:"lockedtoaccount"`
+	Version         int    `json:"version"`
+}
+
+// CreateLoadBalancerParams is used when creating a new loadbalancer
+type CreateLoadBalancerParams struct {
+	DataCenter string `json:"datacenter"`
+	IPv4       string `json:"ip,omitempty"`
+	IPv6       string `json:"ipv6,omitempty"`
+	Name       string `json:"name"`
+}
+
+// EditLoadBalancerParams is used when editing a loadbalancer
+type EditLoadBalancerParams struct {
+	Name string `json:"name"`
+}
+
+// LoadBalancerBackend represents a LoadBalancer Backend
+type LoadBalancerBackend struct {
+	ConnectTimeout  int      `json:"connecttimeout"`
+	Mode            string   `json:"mode"`
+	Name            string   `json:"name"`
+	ResponseTimeout int      `json:"responsetimeout"`
+	Status          string   `json:"status"`
+	StickySession   string   `json:"stickysessions"`
+	Targets         []Target `json:"targets"`
+}
+
+// AddBackendParams used when creating backends
+type AddBackendParams struct {
+	ConnectTimeout  int    `json:"connecttimeout,omitempty"`
+	Mode            string `json:"mode,omitempty"`
+	Name            string `json:"name"`
+	ResponseTimeout int    `json:"responsetimeout,omitempty"`
+	StickySession   string `json:"stickysession,omitempty"`
+}
+
+// EditBackendParams used to edit a backend
+type EditBackendParams struct {
+	ConnectTimeout  int    `json:"connecttimeout,omitempty"`
+	Mode            string `json:"mode,omitempty"`
+	Name            string `json:"backendname"`
+	ResponseTimeout int    `json:"responsetimeout,omitempty"`
+	StickySession   string `json:"stickysession,omitempty"`
+}
+
+// RemoveBackendParams used when removing
+type RemoveBackendParams struct {
+	Name string `json:"backendname"`
+}
+
+// AddCertificateParams represents a certificate name and content
+type AddCertificateParams struct {
+	Name        string `json:"certificatename"`
+	Certificate string `json:"certificate"`
+}
+
+// LoadBalancerFrontend represents a LoadBalancer Frontend
+type LoadBalancerFrontend struct {
+	Backend        string `json:"backend"`
+	ClientTimeout  int    `json:"clienttimeout"`
+	MaxConnections int    `json:"maxconnections"`
+	Name           string `json:"name"`
+	Port           int    `json:"port"`
+	Status         string `json:"status"`
+	SSLCertificate string `json:"sslcertificate"`
+}
+
+// AddFrontendParams used when creating frontends
+type AddFrontendParams struct {
+	Backend        string `json:"backendname"`
+	ClientTimeout  int    `json:"clienttimeout,omitempty"`
+	MaxConnections int    `json:"maxconnections,omitempty"`
+	Name           string `json:"name"`
+	Port           int    `json:"port"`
+	SSLCertificate string `json:"sslcertificate,omitempty"`
+}
+
+// EditFrontendParams used to edit a frontend
+type EditFrontendParams struct {
+	ClientTimeout  int    `json:"clienttimeout,omitempty"`
+	MaxConnections int    `json:"maxconnections,omitempty"`
+	Name           string `json:"frontendname"`
+	Port           int    `json:"port,omitempty"`
+	SSLCertificate string `json:"sslcertificate,omitempty"`
+}
+
+// RemoveFrontendParams used when removing
+type RemoveFrontendParams struct {
+	Name string `json:"frontendname"`
+}
+
+// Target is used in backends
+type Target struct {
+	Enabled  bool   `json:"enabled"`
+	Name     string `json:"name"`
+	Port     int    `json:"port"`
+	Status   string `json:"status"`
+	TargetIP string `json:"ipaddress"`
+	Weight   int    `json:"weight"`
+}
+
+// AddTargetParams used when creating targets
+type AddTargetParams struct {
+	Backend  string `json:"backendname"`
+	Name     string `json:"name"`
+	Port     int    `json:"port"`
+	TargetIP string `json:"ipaddress"`
+	Weight   int    `json:"weight"`
+}
+
+// EditTargetParams used when editing targets
+type EditTargetParams struct {
+	Backend  string `json:"backendname"`
+	Name     string `json:"targetname"`
+	Port     int    `json:"port,omitempty"`
+	TargetIP string `json:"ipaddress,omitempty"`
+	Weight   int    `json:"weight,omitempty"`
+}
+
+// RemoveTargetParams used when removing targets
+type RemoveTargetParams struct {
+	Backend string `json:"backendname"`
+	Name    string `json:"name"`
+}
+
+// BlacklistParams set prefix to add/delete
+type BlacklistParams struct {
+	Prefix string `json:"prefix"`
+}
+
+// ToggleTargetParams used when enabling/disabling targets
+type ToggleTargetParams struct {
+	Backend string `json:"backendname"`
+	Name    string `json:"targetname"`
+}
+
+// Create creates a new loadbalancer
+func (lb *LoadBalancerService) Create(context context.Context, params CreateLoadBalancerParams) (*LoadBalancerDetails, error) {
+	data := struct {
+		Response struct {
+			LoadBalancer LoadBalancerDetails
+		}
+	}{}
+	err := lb.client.post(context, "loadbalancer/create", &data, params)
+	return &data.Response.LoadBalancer, err
+}
+
+// Destroy deletes a loadbalancer
+func (lb *LoadBalancerService) Destroy(context context.Context, loadbalancerID string) error {
+	return lb.client.post(context, "loadbalancer/destroy", nil, struct {
+		LoadBalancerID string `json:"loadbalancerid"`
+	}{loadbalancerID})
+}
+
+// Details returns a detailed information about one loadbalancer
+func (lb *LoadBalancerService) Details(context context.Context, loadbalancerID string) (*LoadBalancerDetails, error) {
+	data := struct {
+		Response struct {
+			LoadBalancer LoadBalancerDetails
+		}
+	}{}
+	err := lb.client.get(context, fmt.Sprintf("loadbalancer/details/loadbalancerid/%s", loadbalancerID), &data)
+	return &data.Response.LoadBalancer, err
+}
+
+// Edit edits a loadbalancer
+func (lb *LoadBalancerService) Edit(context context.Context, loadbalancerID string, params EditLoadBalancerParams) (*LoadBalancerDetails, error) {
+	data := struct {
+		Response struct {
+			LoadBalancer LoadBalancerDetails
+		}
+	}{}
+	err := lb.client.post(context, "loadbalancer/edit", &data, struct {
+		EditLoadBalancerParams
+		LoadBalancerID string `json:"loadbalancerid"`
+	}{params, loadbalancerID})
+	return &data.Response.LoadBalancer, err
+}
+
+// List returns a list of loadbalancers
+func (lb *LoadBalancerService) List(context context.Context) (*[]LoadBalancer, error) {
+	data := struct {
+		Response struct {
+			LoadBalancers []LoadBalancer
+		}
+	}{}
+	err := lb.client.get(context, "loadbalancer/list", &data)
+	return &data.Response.LoadBalancers, err
+}
+
+// AddBackend creates a new backend used by the loadbalancer specified
+func (lb *LoadBalancerService) AddBackend(context context.Context, loadbalancerID string, params AddBackendParams) (*LoadBalancerDetails, error) {
+	data := struct {
+		Response struct {
+			LoadBalancer LoadBalancerDetails
+		}
+	}{}
+	err := lb.client.post(context, "loadbalancer/addbackend", &data, struct {
+		AddBackendParams
+		LoadBalancerID string `json:"loadbalancerid"`
+	}{params, loadbalancerID})
+	return &data.Response.LoadBalancer, err
+}
+
+// EditBackend edits a Backend
+func (lb *LoadBalancerService) EditBackend(context context.Context, loadbalancerID string, params EditBackendParams) (*LoadBalancerDetails, error) {
+	data := struct {
+		Response struct {
+			LoadBalancer LoadBalancerDetails
+		}
+	}{}
+	err := lb.client.post(context, "loadbalancer/editbackend", &data, struct {
+		EditBackendParams
+		LoadBalancerID string `json:"loadbalancerid"`
+	}{params, loadbalancerID})
+	return &data.Response.LoadBalancer, err
+}
+
+// RemoveBackend deletes a backend
+func (lb *LoadBalancerService) RemoveBackend(context context.Context, loadbalancerID string, params RemoveBackendParams) error {
+	return lb.client.post(context, "loadbalancer/removebackend", nil, struct {
+		RemoveBackendParams
+		LoadBalancerID string `json:"loadbalancerid"`
+	}{params, loadbalancerID})
+}
+
+// AddFrontend creates a new frontend used by the loadbalancer specified
+func (lb *LoadBalancerService) AddFrontend(context context.Context, loadbalancerID string, params AddFrontendParams) (*LoadBalancerDetails, error) {
+	data := struct {
+		Response struct {
+			LoadBalancer LoadBalancerDetails
+		}
+	}{}
+	err := lb.client.post(context, "loadbalancer/addfrontend", &data, struct {
+		AddFrontendParams
+		LoadBalancerID string `json:"loadbalancerid"`
+	}{params, loadbalancerID})
+	return &data.Response.LoadBalancer, err
+}
+
+// EditFrontend edits a frontend
+func (lb *LoadBalancerService) EditFrontend(context context.Context, loadbalancerID string, params EditFrontendParams) (*LoadBalancerDetails, error) {
+	data := struct {
+		Response struct {
+			LoadBalancer LoadBalancerDetails
+		}
+	}{}
+	err := lb.client.post(context, "loadbalancer/editfrontend", &data, struct {
+		EditFrontendParams
+		LoadBalancerID string `json:"loadbalancerid"`
+	}{params, loadbalancerID})
+	return &data.Response.LoadBalancer, err
+}
+
+// RemoveFrontend deletes a frontend
+func (lb *LoadBalancerService) RemoveFrontend(context context.Context, loadbalancerID string, params RemoveFrontendParams) error {
+	return lb.client.post(context, "loadbalancer/removefrontend", nil, struct {
+		RemoveFrontendParams
+		LoadBalancerID string `json:"loadbalancerid"`
+	}{params, loadbalancerID})
+}
+
+// AddCertificate adds a certificate to the loadbalancer specified
+func (lb *LoadBalancerService) AddCertificate(context context.Context, loadbalancerID string, params AddCertificateParams) error {
+	data := struct {
+		Response struct {
+			LoadBalancer LoadBalancerDetails
+		}
+	}{}
+	return lb.client.post(context, "loadbalancer/addcertificate", &data, struct {
+		AddCertificateParams
+		LoadBalancerID string `json:"loadbalancerid"`
+	}{params, loadbalancerID})
+}
+
+// ListCertificates list certificates for the LoadBalancer
+func (lb *LoadBalancerService) ListCertificates(context context.Context, loadbalancerID string) (*[]string, error) {
+	data := struct {
+		Response struct {
+			Certificates []string `json:"certificate"`
+		}
+	}{}
+	err := lb.client.post(context, "loadbalancer/listcertificate", &data, struct {
+		LoadBalancerID string `json:"loadbalancerid"`
+	}{loadbalancerID})
+
+	return &data.Response.Certificates, err
+}
+
+// RemoveCertificate deletes a certificate from the loadbalancer
+func (lb *LoadBalancerService) RemoveCertificate(context context.Context, loadbalancerID string, params string) error {
+	return lb.client.post(context, "loadbalancer/removecertificate", nil, struct {
+		CertificateName string `json:"certificatename"`
+		LoadBalancerID  string `json:"loadbalancerid"`
+	}{params, loadbalancerID})
+}
+
+// AddTarget adds a target to the backend specified
+func (lb *LoadBalancerService) AddTarget(context context.Context, loadbalancerID string, params AddTargetParams) (*LoadBalancerDetails, error) {
+	data := struct {
+		Response struct {
+			LoadBalancer LoadBalancerDetails
+		}
+	}{}
+	err := lb.client.post(context, "loadbalancer/addtarget", &data, struct {
+		AddTargetParams
+		LoadBalancerID string `json:"loadbalancerid"`
+	}{params, loadbalancerID})
+	return &data.Response.LoadBalancer, err
+}
+
+// EditTarget edits a target for the specified backend
+func (lb *LoadBalancerService) EditTarget(context context.Context, loadbalancerID string, params EditTargetParams) (*LoadBalancerDetails, error) {
+	data := struct {
+		Response struct {
+			LoadBalancer LoadBalancerDetails
+		}
+	}{}
+	err := lb.client.post(context, "loadbalancer/edittarget", &data, struct {
+		EditTargetParams
+		LoadBalancerID string `json:"loadbalancerid"`
+	}{params, loadbalancerID})
+	return &data.Response.LoadBalancer, err
+}
+
+// EnableTarget enables a target for the specified LoadBalancerBackend
+func (lb *LoadBalancerService) EnableTarget(context context.Context, loadbalancerID string, params ToggleTargetParams) (*LoadBalancerDetails, error) {
+	data := struct {
+		Response struct {
+			LoadBalancer LoadBalancerDetails
+		}
+	}{}
+	err := lb.client.post(context, "loadbalancer/enabletarget", &data, struct {
+		ToggleTargetParams
+		LoadBalancerID string `json:"loadbalancerid"`
+	}{params, loadbalancerID})
+	return &data.Response.LoadBalancer, err
+}
+
+// DisableTarget disables the specified target for the LoadBalancerBackend
+func (lb *LoadBalancerService) DisableTarget(context context.Context, loadbalancerID string, params ToggleTargetParams) (*LoadBalancerDetails, error) {
+	data := struct {
+		Response struct {
+			LoadBalancer LoadBalancerDetails
+		}
+	}{}
+	err := lb.client.post(context, "loadbalancer/disabletarget", &data, struct {
+		ToggleTargetParams
+		LoadBalancerID string `json:"loadbalancerid"`
+	}{params, loadbalancerID})
+	return &data.Response.LoadBalancer, err
+}
+
+// RemoveTarget deletes a target from the specified LoadBalancerBackend
+func (lb *LoadBalancerService) RemoveTarget(context context.Context, loadbalancerID string, params RemoveTargetParams) error {
+	return lb.client.post(context, "loadbalancer/removetarget", nil, struct {
+		RemoveTargetParams
+		LoadBalancerID string `json:"loadbalancerid"`
+	}{params, loadbalancerID})
+}
+
+// AddToBlacklist adds a prefix to loadbalancer blacklist
+func (lb *LoadBalancerService) AddToBlacklist(context context.Context, loadbalancerID string, params BlacklistParams) (*LoadBalancerDetails, error) {
+	data := struct {
+		Response struct {
+			LoadBalancer LoadBalancerDetails
+		}
+	}{}
+	err := lb.client.post(context, "loadbalancer/addtoblacklist", &data, struct {
+		BlacklistParams
+		LoadBalancerID string `json:"loadbalancerid"`
+	}{params, loadbalancerID})
+	return &data.Response.LoadBalancer, err
+}
+
+// RemoveFromBlacklist deletes a prefix from the LoadBalancer blacklist
+func (lb *LoadBalancerService) RemoveFromBlacklist(context context.Context, loadbalancerID string, params BlacklistParams) (*LoadBalancerDetails, error) {
+	data := struct {
+		Response struct {
+			LoadBalancer LoadBalancerDetails
+		}
+	}{}
+	err := lb.client.post(context, "loadbalancer/removefromblacklist", &data, struct {
+		BlacklistParams
+		LoadBalancerID string `json:"loadbalancerid"`
+	}{params, loadbalancerID})
+	return &data.Response.LoadBalancer, err
+}

--- a/v2/loadbalancers_test.go
+++ b/v2/loadbalancers_test.go
@@ -1,0 +1,389 @@
+package glesys
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadBalancersCreate(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "loadbalancer":
+	{ "backends": [], "datacenter": "Falkenberg", "frontends": [],
+	"ipaddress": [{"ipaddress": "192.168.0.1", "version": 4}],
+	"name": "myloadbalancer", "loadbalancerid": "lb123456" }}}`}
+	lb := LoadBalancerService{client: c}
+
+	params := CreateLoadBalancerParams{
+		DataCenter: "Falkenberg",
+		IPv4:       "192.168.0.1",
+		Name:       "myloadbalancer",
+	}
+
+	loadbalancer, _ := lb.Create(context.Background(), params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method is used correct")
+	assert.Equal(t, "loadbalancer/create", c.lastPath, "path used is correct")
+	assert.Equal(t, "lb123456", loadbalancer.ID, "loadbalancer ID is correct")
+	assert.Equal(t, "Falkenberg", loadbalancer.DataCenter, "loadbalancer DataCenter is correct")
+	assert.Equal(t, "myloadbalancer", loadbalancer.Name, "loadbalancer Name is correct")
+	assert.Equal(t, "192.168.0.1", loadbalancer.IPList[0].Address, "loadbalancer ip is correct")
+}
+
+func TestLoadBalancersDestroy(t *testing.T) {
+	c := &mockClient{body: `{"response": {"status":{"code": 200,
+	"timestamp": "2019-01-01T12:00:00+02:00", "text": "Deleted Loadbalancer", "transactionid": "None" }}}`}
+	lb := LoadBalancerService{client: c}
+
+	lb.Destroy(context.Background(), "lb123456")
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "loadbalancer/destroy", c.lastPath, "path used is correct")
+}
+
+func TestLoadBalancersDetails(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "loadbalancer":
+	{ "backends": [], "datacenter": "Falkenberg", "frontends": [],
+	"ipaddress": [{"ipaddress": "192.168.0.1", "version": 4}],
+	"name": "myloadbalancer", "loadbalancerid": "lb123456" }}}`}
+	lb := LoadBalancerService{client: c}
+
+	loadbalancer, _ := lb.Details(context.Background(), "lb123456")
+
+	assert.Equal(t, "GET", c.lastMethod, "method used is correct")
+	assert.Equal(t, "loadbalancer/details/loadbalancerid/lb123456", c.lastPath, "path used is correct")
+	assert.Equal(t, "myloadbalancer", loadbalancer.Name, "loadbalancer Name is correct")
+	assert.Equal(t, "Falkenberg", loadbalancer.DataCenter, "loadbalancer DataCenter is correct")
+}
+
+func TestLoadlancersEdit(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "loadbalancer":
+	{ "backends": [], "datacenter": "Falkenberg", "frontends": [],
+	"ipaddress": [{"ipaddress": "192.168.0.1", "version": 4}],
+	"name": "newloadbalancername", "loadbalancerid": "lb123456" }}}`}
+
+	lb := LoadBalancerService{client: c}
+
+	params := EditLoadBalancerParams{
+		Name: "newloadbalancername",
+	}
+
+	lb.Edit(context.Background(), "lb123456", params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "loadbalancer/edit", c.lastPath, "path used is correct")
+}
+
+func TestLoadBalancersList(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "loadbalancers": [
+		{ "backends": [], "datacenter": "Falkenberg", "frontends": [],
+		"ipaddress": [{"ipaddress": "192.168.0.1", "version": 4}],
+		"name": "myloadbalancer", "loadbalancerid": "lb123456" }]
+		}}`}
+	lb := LoadBalancerService{client: c}
+
+	loadbalancers, _ := lb.List(context.Background())
+
+	assert.Equal(t, "GET", c.lastMethod, "method used is correct")
+	assert.Equal(t, "loadbalancer/list", c.lastPath, "path used is correct")
+	assert.Equal(t, "myloadbalancer", (*loadbalancers)[0].Name, "loadbalancer Name is correct")
+	assert.Equal(t, "Falkenberg", (*loadbalancers)[0].DataCenter, "loadbalancer DataCenter is correct")
+}
+
+func TestLoadBalancersAddBackend(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "loadbalancer": {
+		"backends": [{"connecttimeout": 4000, "mode": "tcp", "name": "mybackend",
+		"stickysessions": "no", "targets": [] }],
+		"loadbalancerid": "lb123456"}}}`}
+
+	lb := LoadBalancerService{client: c}
+	params := AddBackendParams{
+		Name:          "mybackend",
+		Mode:          "tcp",
+		StickySession: "no",
+	}
+
+	loadbalancer, _ := lb.AddBackend(context.Background(), "lb123456", params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "loadbalancer/addbackend", c.lastPath, "path used is correct")
+	assert.Equal(t, "mybackend", loadbalancer.BackendsList[0].Name, "backend name is correct")
+	assert.Equal(t, "tcp", loadbalancer.BackendsList[0].Mode, "backend mode is correct")
+}
+
+func TestLoadBalancersEditBackend(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "loadbalancer": {
+		"backends": [{"connecttimeout": 4000, "mode": "http", "name": "mybackend",
+		"stickysessions": "no", "targets": [] }],
+		"loadbalancerid": "lb123456"}}}`}
+	lb := LoadBalancerService{client: c}
+
+	params := EditBackendParams{
+		Name: "mybackend",
+		Mode: "http",
+	}
+
+	lb.EditBackend(context.Background(), "lb123456", params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "loadbalancer/editbackend", c.lastPath, "path used is correct")
+}
+
+func TestLoadBalancersRemoveBackend(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "loadbalancer": {
+		"backends": [], "loadbalancerid": "lb123456"}}}`}
+
+	lb := LoadBalancerService{client: c}
+	params := RemoveBackendParams{
+		Name: "mybackend",
+	}
+
+	lb.RemoveBackend(context.Background(), "lb123456", params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "loadbalancer/removebackend", c.lastPath, "path used is correct")
+}
+
+func TestLoadBalancersAddFrontend(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "loadbalancer": {
+		"backends": [{"connecttimeout": 4000, "mode": "tcp", "name": "mybackend",
+		"stickysessions": "no", "targets": [] }],
+		"frontends": [{"backend": "mybackend", "name": "myfrontend", "port": 8080}],
+		"loadbalancerid": "lb123456"}}}`}
+
+	lb := LoadBalancerService{client: c}
+	params := AddFrontendParams{
+		Backend: "mybackend",
+		Name:    "myfrontend",
+		Port:    8080,
+	}
+
+	loadbalancer, _ := lb.AddFrontend(context.Background(), "lb123456", params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "loadbalancer/addfrontend", c.lastPath, "path used is correct")
+	assert.Equal(t, "myfrontend", loadbalancer.FrontendsList[0].Name, "Frontend name is correct")
+	assert.Equal(t, 8080, loadbalancer.FrontendsList[0].Port, "Frontend port is correct")
+}
+
+func TestLoadBalancersEditFrontend(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "loadbalancer": {
+		"backends": [{"connecttimeout": 4000, "mode": "tcp", "name": "mybackend",
+		"stickysessions": "no", "targets": [] }],
+		"frontends": [{"backend": "mybackend", "name": "myfrontend", "port": 7000}],
+		"loadbalancerid": "lb123456"}}}`}
+	lb := LoadBalancerService{client: c}
+
+	params := EditFrontendParams{
+		Name: "myfrontend",
+		Port: 7000,
+	}
+
+	lb.EditFrontend(context.Background(), "lb123456", params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "loadbalancer/editfrontend", c.lastPath, "path used is correct")
+}
+
+func TestLoadBalancersRemoveFrontend(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "loadbalancer": {
+		"frontends": [], "loadbalancerid": "lb123456"}}}`}
+
+	lb := LoadBalancerService{client: c}
+	params := RemoveFrontendParams{
+		Name: "myfrontend",
+	}
+
+	lb.RemoveFrontend(context.Background(), "lb123456", params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "loadbalancer/removefrontend", c.lastPath, "path used is correct")
+}
+
+func TestLoadBalancersAddTarget(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "loadbalancer": {
+		"backends": [{"connecttimeout": 4000, "mode": "tcp", "name": "mybackend", "stickysessions": "no",
+			"targets": [{"ipaddress": "8.8.8.8", "name": "mytarget", "port": 8080, "status": "DOWN", "weight": 10}]
+			}],
+		"loadbalancerid": "lb123456"}}}`}
+
+	lb := LoadBalancerService{client: c}
+
+	params := AddTargetParams{
+		Backend:  "mybackend",
+		Name:     "mytarget",
+		Port:     8080,
+		TargetIP: "8.8.8.8",
+		Weight:   10,
+	}
+
+	loadbalancer, _ := lb.AddTarget(context.Background(), "lb123456", params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "loadbalancer/addtarget", c.lastPath, "path used is correct")
+	assert.Equal(t, "mytarget", loadbalancer.BackendsList[0].Targets[0].Name, "Target name is correct")
+	assert.Equal(t, 8080, loadbalancer.BackendsList[0].Targets[0].Port, "Target port is correct")
+	assert.Equal(t, 10, loadbalancer.BackendsList[0].Targets[0].Weight, "Target weight is correct")
+}
+
+func TestLoadBalancersEditTarget(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "loadbalancer": {
+		"backends": [{"connecttimeout": 4000, "mode": "tcp", "name": "mybackend", "stickysessions": "no",
+			"targets": [{"ipaddress": "8.8.8.8", "name": "mytarget", "port": 8080, "status": "DOWN", "weight": 10}]
+			}],
+		"loadbalancerid": "lb123456"}}}`}
+
+	lb := LoadBalancerService{client: c}
+
+	params := EditTargetParams{
+		Backend:  "mybackend",
+		Name:     "mytarget",
+		Port:     8080,
+		TargetIP: "8.8.8.8",
+		Weight:   10,
+	}
+
+	lb.EditTarget(context.Background(), "lb123456", params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "loadbalancer/edittarget", c.lastPath, "path used is correct")
+}
+
+func TestLoadBalancersEnableTarget(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "loadbalancer": {
+		"backends": [{"connecttimeout": 4000, "mode": "tcp", "name": "mybackend", "stickysessions": "no",
+			"targets": [{"ipaddress": "8.8.8.8", "name": "mytarget", "port": 8080, "status": "MAINT", "weight": 10}]
+			}],
+		"loadbalancerid": "lb123456"}}}`}
+
+	lb := LoadBalancerService{client: c}
+
+	params := ToggleTargetParams{
+		Backend: "mybackend",
+		Name:    "mytarget",
+	}
+
+	lb.EnableTarget(context.Background(), "lb123456", params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "loadbalancer/enabletarget", c.lastPath, "path used is correct")
+}
+
+func TestLoadBalancersDisableTarget(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "loadbalancer": {
+		"backends": [{"connecttimeout": 4000, "mode": "tcp", "name": "mybackend", "stickysessions": "no",
+			"targets": [{"ipaddress": "8.8.8.8", "name": "mytarget", "port": 8080, "status": "MAINT", "weight": 10}]
+			}],
+		"loadbalancerid": "lb123456"}}}`}
+
+	lb := LoadBalancerService{client: c}
+
+	params := ToggleTargetParams{
+		Backend: "mybackend",
+		Name:    "mytarget",
+	}
+
+	lb.DisableTarget(context.Background(), "lb123456", params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "loadbalancer/disabletarget", c.lastPath, "path used is correct")
+}
+
+func TestLoadBalancersRemoveTarget(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "loadbalancer": { "backends":
+	[{"connecttimeout": 4000, "mode": "tcp", "name": "mybackend", "stickysessions": "no", "targets": [] }], "loadbalancerid": "lb123456"}}}`}
+	lb := LoadBalancerService{client: c}
+
+	params := RemoveTargetParams{
+		Backend: "mybackend",
+		Name:    "mytarget",
+	}
+
+	lb.RemoveTarget(context.Background(), "lb123456", params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "loadbalancer/removetarget", c.lastPath, "path used is correct")
+}
+
+func TestLoadBalancersAddToBlacklist(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "loadbalancer":
+	{ "backends": [], "blacklist": ["10.0.0.10/32"], "datacenter": "Falkenberg", "frontends": [],
+	"ipaddress": [{"ipaddress": "192.168.0.1", "version": 4}],
+	"name": "myloadbalancer", "loadbalancerid": "lb123456" }}}`}
+
+	lb := LoadBalancerService{client: c}
+
+	params := BlacklistParams{
+		Prefix: "10.0.0.10/32",
+	}
+
+	lbd, _ := lb.AddToBlacklist(context.Background(), "lb123456", params)
+	myprefix := strings.Join(lbd.Blacklists, " ")
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "loadbalancer/addtoblacklist", c.lastPath, "path used is correct")
+	assert.Equal(t, "10.0.0.10/32", myprefix, "prefix set correct")
+}
+
+func TestLoadBalancersRemoveFromBlacklist(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "loadbalancers": {
+		"backends": [{'name': 'my-backend'}], "blacklist": [],
+		"name": "myloadbalancer", "loadbalancerid": "lb123456" }
+	}}`}
+
+	lb := LoadBalancerService{client: c}
+
+	params := BlacklistParams{
+		Prefix: "10.0.0.10/32",
+	}
+
+	lbd, _ := lb.RemoveFromBlacklist(context.Background(), "lb123456", params)
+	myprefix := strings.Join(lbd.Blacklists, " ")
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "loadbalancer/removefromblacklist", c.lastPath, "path used is correct")
+	assert.Equal(t, "", myprefix, "prefix correctly absent")
+}
+
+func TestLoadBalancersAddCertificate(t *testing.T) {
+	c := &mockClient{body: `{"response": {"status":{"code": 200,
+	"timestamp": "2019-01-01T12:00:00+02:00", "text": "OK", "transactionid": "None" }}}`}
+
+	lb := LoadBalancerService{client: c}
+
+	params := AddCertificateParams{
+		Name:        "mycert",
+		Certificate: "ABC123==",
+	}
+
+	lb.AddCertificate(context.Background(), "lb123456", params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "loadbalancer/addcertificate", c.lastPath, "path used is correct")
+}
+
+func TestLoadBalancersListCertificates(t *testing.T) {
+	c := &mockClient{body: `{"response": {"status":{"code": 200,
+	"timestamp": "2019-01-01T12:00:00+02:00", "text": "OK", "transactionid": "None" }
+	"certificate": ["mycert"]}}`}
+
+	lb := LoadBalancerService{client: c}
+
+	lb.ListCertificates(context.Background(), "lb123456")
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "loadbalancer/listcertificate", c.lastPath, "path used is correct")
+}
+
+func TestLoadBalancersRemoveCertificate(t *testing.T) {
+	c := &mockClient{body: `{"response": {"status":{"code": 200,
+	"timestamp": "2019-01-01T13:00:00+02:00", "text": "OK", "transactionid": "None" }}}`}
+
+	lb := LoadBalancerService{client: c}
+
+	lb.RemoveCertificate(context.Background(), "lb123456", "mycert")
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "loadbalancer/removecertificate", c.lastPath, "path used is correct")
+}

--- a/v2/networkadapters.go
+++ b/v2/networkadapters.go
@@ -1,0 +1,89 @@
+package glesys
+
+import (
+	"context"
+	"fmt"
+)
+
+// NetworkAdapterService provides functions to interact with Networks
+type NetworkAdapterService struct {
+	client clientInterface
+}
+
+// NetworkAdapter represents a networkadapter
+type NetworkAdapter struct {
+	AdapterType string `json:"adaptertype,omitempty"`
+	Bandwidth   int    `json:"bandwidth"`
+	ID          string `json:"networkadapterid"`
+	Name        string `json:"name"`
+	NetworkID   string `json:"networkid"`
+	ServerID    string `json:"serverid"`
+	State       string `json:"state"`
+}
+
+// IsLocked returns true if the network adapter is currently locked, false otherwise
+func (na *NetworkAdapter) IsLocked() bool {
+	return na.State == "locked"
+}
+
+// IsReady returns true if the network adapter is currently ready, false otherwise
+func (na *NetworkAdapter) IsReady() bool {
+	return na.State == "ready"
+}
+
+// CreateNetworkAdapterParams is used when creating a new network adapter
+type CreateNetworkAdapterParams struct {
+	AdapterType string `json:"adaptertype,omitempty"`
+	Bandwidth   int    `json:"bandwidth,omitempty"`
+	NetworkID   string `json:"networkid,omitempty"`
+	ServerID    string `json:"serverid"`
+}
+
+// EditNetworkAdapterParams is used when editing an existing network adapter
+type EditNetworkAdapterParams struct {
+	Bandwidth int    `json:"bandwidth,omitempty"`
+	NetworkID string `json:"networkid,omitempty"`
+}
+
+// Create creates a new NetworkAdapter
+func (s *NetworkAdapterService) Create(context context.Context, params CreateNetworkAdapterParams) (*NetworkAdapter, error) {
+	data := struct {
+		Response struct {
+			NetworkAdapter NetworkAdapter
+		}
+	}{}
+	err := s.client.post(context, "networkadapter/create", &data, params)
+	return &data.Response.NetworkAdapter, err
+}
+
+// Details returns detailed information about a NetworkAdapter
+func (s *NetworkAdapterService) Details(context context.Context, networkAdapterID string) (*NetworkAdapter, error) {
+	data := struct {
+		Response struct {
+			NetworkAdapter NetworkAdapter
+		}
+	}{}
+	err := s.client.get(context, fmt.Sprintf("networkadapter/details/networkadapterid/%s", networkAdapterID), &data)
+	return &data.Response.NetworkAdapter, err
+}
+
+// Destroy deletes a NetworkAdapter
+func (s *NetworkAdapterService) Destroy(context context.Context, networkAdapterID string) error {
+	return s.client.post(context, "networkadapter/delete", nil, struct {
+		NetworkAdapterID string `json:"networkadapterid"`
+	}{networkAdapterID})
+}
+
+// Edit modifies a NetworkAdapter
+func (s *NetworkAdapterService) Edit(context context.Context, networkAdapterID string, params EditNetworkAdapterParams) (*NetworkAdapter, error) {
+	data := struct {
+		Response struct {
+			NetworkAdapter NetworkAdapter
+		}
+	}{}
+	err := s.client.post(context, "networkadapter/edit", &data, struct {
+		EditNetworkAdapterParams
+		NetworkAdapterID string `json:"networkadapterid"`
+	}{params, networkAdapterID})
+	return &data.Response.NetworkAdapter, err
+}

--- a/v2/networkadapters_test.go
+++ b/v2/networkadapters_test.go
@@ -1,0 +1,102 @@
+package glesys
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNetworkAdapterIsLocked(t *testing.T) {
+	networkadapter := NetworkAdapter{}
+
+	assert.Equal(t, false, networkadapter.IsLocked(), "should not be locked")
+
+	networkadapter.State = "locked"
+	assert.Equal(t, true, networkadapter.IsLocked(), "should be locked")
+}
+
+func TestNetworkAdapterIsReady(t *testing.T) {
+	networkadapter := NetworkAdapter{}
+
+	assert.Equal(t, false, networkadapter.IsReady(), "should not be ready")
+
+	networkadapter.State = "ready"
+	assert.Equal(t, true, networkadapter.IsReady(), "should be ready")
+}
+
+func TestNetworkAdaptersCreate(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "networkadapter":
+	{ "adaptertype": "E1000", "bandwidth": 10, "name": "Network Adapter 2", "networkid": "mynetwork",
+	"networkadapterid": "ab12cd34-dcba-0123-abcd-abc123456789", "serverid": "vz123456" }}}`}
+	n := NetworkAdapterService{client: c}
+
+	params := CreateNetworkAdapterParams{
+		Bandwidth: 10,
+		NetworkID: "mynetwork",
+		ServerID:  "vz123456",
+	}
+
+	networkadapter, _ := n.Create(context.Background(), params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method is used correct")
+	assert.Equal(t, "networkadapter/create", c.lastPath, "path used is correct")
+	assert.Equal(t, "vz123456", networkadapter.ServerID, "networkadapter ServerID is correct")
+	assert.Equal(t, "Network Adapter 2", networkadapter.Name, "networkadapter Name is correct")
+	assert.Equal(t, "mynetwork", networkadapter.NetworkID, "networkadapter Description is correct")
+}
+
+func TestNetworkAdaptersDestroy(t *testing.T) {
+	c := &mockClient{}
+	n := NetworkAdapterService{client: c}
+
+	n.Destroy(context.Background(), "ab12cd34-dcba-0123-abcd-abc123456789")
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "networkadapter/delete", c.lastPath, "path used is correct")
+}
+
+func TestNetworkAdaptersDetails(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "networkadapter": {
+		"networkadapterid": "9ac61694-eb4d-4011-9d10-c395ba5f7269",
+		"bandwidth": 100,
+		"name": "My Network Adapter",
+		"adaptertype": "VMXNET 3",
+		"state": "ready",
+		"serverid": "vz123456",
+		"networkid": "internet-fbg"
+		} } }`}
+	s := NetworkAdapterService{client: c}
+
+	networkAdapter, _ := s.Details(context.Background(), "9ac61694-eb4d-4011-9d10-c395ba5f7269")
+
+	assert.Equal(t, "GET", c.lastMethod, "method used is correct")
+	assert.Equal(t, "networkadapter/details/networkadapterid/9ac61694-eb4d-4011-9d10-c395ba5f7269", c.lastPath, "path used is correct")
+	assert.Equal(t, "VMXNET 3", networkAdapter.AdapterType, "network adapter Bandwidth is correct")
+	assert.Equal(t, 100, networkAdapter.Bandwidth, "network adapter Bandwidth is correct")
+	assert.Equal(t, "9ac61694-eb4d-4011-9d10-c395ba5f7269", networkAdapter.ID, "network adapter Bandwidth is correct")
+	assert.Equal(t, "My Network Adapter", networkAdapter.Name, "network adapter Bandwidth is correct")
+	assert.Equal(t, "internet-fbg", networkAdapter.NetworkID, "network adapter Bandwidth is correct")
+	assert.Equal(t, "vz123456", networkAdapter.ServerID, "network adapter Bandwidth is correct")
+	assert.Equal(t, "ready", networkAdapter.State, "network adapter Bandwidth is correct")
+}
+
+func TestNetworkAdaptersEdit(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "networkadapter":
+	{ "adaptertype": "E1000", "bandwidth": 100, "name": "Network Adapter 2", "networkid": "mynewnetwork",
+	"networkadapterid": "ab12cd34-dcba-0123-abcd-abc123456789", "serverid": "vz123456" }}}`}
+	n := NetworkAdapterService{client: c}
+
+	params := EditNetworkAdapterParams{
+		Bandwidth: 100,
+		NetworkID: "mynewnetwork",
+	}
+
+	networkadapter, _ := n.Edit(context.Background(), "ab12cd34-dcba-0123-abcd-abc123456789", params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method is used correct")
+	assert.Equal(t, "networkadapter/edit", c.lastPath, "path used is correct")
+	assert.Equal(t, "ab12cd34-dcba-0123-abcd-abc123456789", networkadapter.ID, "networkadapter ID is correct")
+	assert.Equal(t, "mynewnetwork", networkadapter.NetworkID, "networkadapter network ID is correct")
+	assert.Equal(t, 100, networkadapter.Bandwidth, "networkadapter Bandwidth is correct")
+}

--- a/v2/networks.go
+++ b/v2/networks.go
@@ -1,0 +1,90 @@
+package glesys
+
+import (
+	"context"
+	"fmt"
+)
+
+// NetworkService provides functions to interact with Networks
+type NetworkService struct {
+	client clientInterface
+}
+
+// Network represents a network
+type Network struct {
+	DataCenter  string `json:"datacenter"`
+	Description string `json:"description"`
+	ID          string `json:"networkid"`
+	Public      string `json:"public"`
+}
+
+// CreateNetworkParams is used when creating a new network
+type CreateNetworkParams struct {
+	DataCenter  string `json:"datacenter"`
+	Description string `json:"description"`
+}
+
+// EditNetworkParams is used when editing an existing network
+type EditNetworkParams struct {
+	Description string `json:"description"`
+}
+
+// Create creates a new network
+func (s *NetworkService) Create(context context.Context, params CreateNetworkParams) (*Network, error) {
+	data := struct {
+		Response struct {
+			Network Network
+		}
+	}{}
+	err := s.client.post(context, "network/create", &data, params)
+	return &data.Response.Network, err
+}
+
+// Details returns detailed information about one network
+func (s *NetworkService) Details(context context.Context, networkID string) (*Network, error) {
+	data := struct {
+		Response struct {
+			Network Network
+		}
+	}{}
+	err := s.client.get(context, fmt.Sprintf("network/details/networkid/%s", networkID), &data)
+	return &data.Response.Network, err
+}
+
+// Destroy deletes a network
+func (s *NetworkService) Destroy(context context.Context, networkID string) error {
+	return s.client.post(context, "network/delete", nil, struct {
+		NetworkID string `json:"networkid"`
+	}{networkID})
+}
+
+// Edit modifies a network
+func (s *NetworkService) Edit(context context.Context, networkID string, params EditNetworkParams) (*Network, error) {
+	data := struct {
+		Response struct {
+			Network Network
+		}
+	}{}
+	err := s.client.post(context, "network/edit", &data, struct {
+		EditNetworkParams
+		NetworkID string `json:"networkid"`
+	}{params, networkID})
+	return &data.Response.Network, err
+}
+
+// IsPublic return true if network is public
+func (s *Network) IsPublic() bool {
+	return s.Public == "yes"
+}
+
+// List returns a list of Networks available under your account
+func (s *NetworkService) List(context context.Context) (*[]Network, error) {
+	data := struct {
+		Response struct {
+			Networks []Network
+		}
+	}{}
+
+	err := s.client.get(context, "network/list", &data)
+	return &data.Response.Networks, err
+}

--- a/v2/networks_test.go
+++ b/v2/networks_test.go
@@ -1,0 +1,97 @@
+package glesys
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNetworksCreate(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "network":
+		{ "datacenter": "Falkenberg", "description": "mynetwork", "networkid": "vl123456" }}}`}
+	n := NetworkService{client: c}
+
+	params := CreateNetworkParams{
+		DataCenter:  "Falkenberg",
+		Description: "mynetwork",
+	}
+
+	network, _ := n.Create(context.Background(), params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method is used correct")
+	assert.Equal(t, "network/create", c.lastPath, "path used is correct")
+	assert.Equal(t, "vl123456", network.ID, "network ID is correct")
+	assert.Equal(t, "Falkenberg", network.DataCenter, "network DataCenter is correct")
+	assert.Equal(t, "mynetwork", network.Description, "network Description is correct")
+}
+
+func TestNetworksDestroy(t *testing.T) {
+	c := &mockClient{}
+	n := NetworkService{client: c}
+
+	n.Destroy(context.Background(), "vl123456")
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "network/delete", c.lastPath, "path used is correct")
+}
+
+func TestNetworksDetails(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "network": {
+		"networkid": "vl123456",
+		"description": "My Network",
+		"datacenter": "Falkenberg",
+		"public": "no"
+		} } }`}
+	s := NetworkService{client: c}
+
+	network, _ := s.Details(context.Background(), "vl123456")
+
+	assert.Equal(t, "GET", c.lastMethod, "method used is correct")
+	assert.Equal(t, "network/details/networkid/vl123456", c.lastPath, "path used is correct")
+	assert.Equal(t, "Falkenberg", network.DataCenter, "network DataCenter is correct")
+	assert.Equal(t, "My Network", network.Description, "network Description is correct")
+	assert.Equal(t, "vl123456", network.ID, "network ID is correct")
+	assert.Equal(t, "no", network.Public, "network Public is correct")
+}
+
+func TestNetworksEdit(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "network":
+		{ "datacenter": "Falkenberg", "description": "mynewnetwork", "networkid": "vl123456" }}}`}
+	n := NetworkService{client: c}
+
+	params := EditNetworkParams{
+		Description: "mynetwork",
+	}
+
+	network, _ := n.Edit(context.Background(), "vl123456", params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method is used correct")
+	assert.Equal(t, "network/edit", c.lastPath, "path used is correct")
+	assert.Equal(t, "vl123456", network.ID, "network ID is correct")
+	assert.Equal(t, "Falkenberg", network.DataCenter, "network DataCenter is correct")
+	assert.Equal(t, "mynewnetwork", network.Description, "network Description is correct")
+}
+
+func TestNetworksIsPublic(t *testing.T) {
+	network := Network{Public: "yes"}
+	assert.Equal(t, true, network.IsPublic(), "should be public")
+
+	network.Public = "no"
+	assert.Equal(t, false, network.IsPublic(), "should not be public")
+}
+
+func TestNetworksList(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "networks":
+	[{ "datacenter": "Falkenberg", "description": "Internet", "networkid": "internet-fbg", "public": "yes"}] } }`}
+	n := NetworkService{client: c}
+
+	networks, _ := n.List(context.Background())
+
+	assert.Equal(t, "GET", c.lastMethod, "method used is correct")
+	assert.Equal(t, "network/list", c.lastPath, "path used is correct")
+	assert.Equal(t, "Falkenberg", (*networks)[0].DataCenter, "network DataCenter is correct")
+	assert.Equal(t, "yes", (*networks)[0].Public, "network is public")
+	assert.Equal(t, "Internet", (*networks)[0].Description, "network Description is correct")
+	assert.Equal(t, "internet-fbg", (*networks)[0].ID, "network ID is correct")
+}

--- a/v2/servers.go
+++ b/v2/servers.go
@@ -1,0 +1,228 @@
+package glesys
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/imdario/mergo"
+)
+
+// ServerService provides functions to interact with servers
+type ServerService struct {
+	client clientInterface
+}
+
+// Server is a simplified version of a server
+type Server struct {
+	DataCenter string `json:"datacenter"`
+	Hostname   string `json:"hostname"`
+	ID         string `json:"serverid"`
+	Platform   string `json:"platform"`
+}
+
+// User represents a system user when creating servers (currently supported in KVM)
+type User struct {
+	Username     string   `json:"username"`
+	PublicKeys   []string `json:"sshkeys,omitempty"`
+	Password     string   `json:"password,omitempty"`
+}
+
+// ServerDetails is a more complete representation of a server
+type ServerDetails struct {
+	CPU         int    `json:"cpucores"`
+	Bandwidth   int    `json:"bandwidth"`
+	DataCenter  string `json:"datacenter"`
+	Description string `json:"description"`
+	Hostname    string `json:"hostname"`
+	ID          string `json:"serverid"`
+	IPList      []IP   `json:"iplist"`
+	Platform    string `json:"platform"`
+	Memory      int    `json:"memorysize"`
+	State       string `json:"state"`
+	Storage     int    `json:"disksize"`
+	Template    string `json:"templatename"`
+}
+
+// IsLocked returns true if the server is currently locked, false otherwise
+func (sd *ServerDetails) IsLocked() bool {
+	return sd.State == "locked"
+}
+
+// IsRunning returns true if the server is currently running, false otherwise
+func (sd *ServerDetails) IsRunning() bool {
+	return sd.State == "running"
+}
+
+// CreateServerParams is used when creating a new server
+type CreateServerParams struct {
+	Bandwidth    int    `json:"bandwidth"`
+	CampaignCode string `json:"campaigncode,omitempty"`
+	CPU          int    `json:"cpucores"`
+	DataCenter   string `json:"datacenter"`
+	Description  string `json:"description,omitempty"`
+	Hostname     string `json:"hostname"`
+	IPv4         string `json:"ip"`
+	IPv6         string `json:"ipv6"`
+	Memory       int    `json:"memorysize"`
+	Password     string `json:"rootpassword,omitempty"`
+	Platform     string `json:"platform"`
+	PublicKey    string `json:"sshkey,omitempty"`
+	Storage      int    `json:"disksize"`
+	Template     string `json:"templatename"`
+	Users        []User `json:"users,omitempty"`
+}
+
+// EditServerParams is used when editing an existing server
+type EditServerParams struct {
+	Bandwidth   int    `json:"bandwidth,omitempty"`
+	CPU         int    `json:"cpucores,omitempty"`
+	Description string `json:"description,omitempty"`
+	Hostname    string `json:"hostname,omitempty"`
+	Memory      int    `json:"memorysize,omitempty"`
+	Storage     int    `json:"disksize,omitempty"`
+}
+
+// WithDefaults populates the parameters with default values. Existing
+// parameters will not be overwritten.
+func (p CreateServerParams) WithDefaults() CreateServerParams {
+	defaults := CreateServerParams{
+		Bandwidth:  100,
+		CPU:        2,
+		DataCenter: "Falkenberg",
+		Hostname:   generateHostname(),
+		IPv4:       "any",
+		IPv6:       "any",
+		Memory:     2048,
+		Platform:   "OpenVZ",
+		Storage:    50,
+		Template:   "Debian 8 64-bit",
+	}
+	mergo.Merge(&p, defaults)
+	return p
+}
+
+// WithUser populates the Users parameter of CreateServerParams for platforms with user support eg. KVM
+// Existing parameters will not be overwritten.
+func (p CreateServerParams) WithUser(username string, publicKeys []string, password string) CreateServerParams {
+
+	p.Users = append(p.Users , User{
+		username,
+		publicKeys,
+		password,
+	})
+	return p
+}
+
+// DestroyServerParams is used when destroying a server
+type DestroyServerParams struct {
+	KeepIP bool `json:"keepip"`
+}
+
+// StopServerParams is used when stopping a server. Supported types are `soft`
+// `hard` and `reboot`.
+type StopServerParams struct {
+	Type string `json:"type"`
+}
+
+// Create creates a new server
+func (s *ServerService) Create(context context.Context, params CreateServerParams) (*ServerDetails, error) {
+	data := struct {
+		Response struct {
+			Server ServerDetails
+		}
+	}{}
+	err := s.client.post(context, "server/create", &data, params)
+	return &data.Response.Server, err
+}
+
+// Destroy deletes a server
+func (s *ServerService) Destroy(context context.Context, serverID string, params DestroyServerParams) error {
+	return s.client.post(context, "server/destroy", nil, struct {
+		DestroyServerParams
+		ServerID string `json:"serverid"`
+	}{params, serverID})
+}
+
+// Details returns detailed information about one server
+func (s *ServerService) Details(context context.Context, serverID string) (*ServerDetails, error) {
+	data := struct {
+		Response struct {
+			Server ServerDetails
+		}
+	}{}
+	err := s.client.get(context, fmt.Sprintf("server/details/serverid/%s/includestate/yes", serverID), &data)
+	return &data.Response.Server, err
+}
+
+// Edit modifies a server
+func (s *ServerService) Edit(context context.Context, serverID string, params EditServerParams) (*ServerDetails, error) {
+	data := struct {
+		Response struct {
+			Server ServerDetails
+		}
+	}{}
+	err := s.client.post(context, "server/edit", &data, struct {
+		EditServerParams
+		ServerID string `json:"serverid"`
+	}{params, serverID})
+	return &data.Response.Server, err
+}
+
+// List returns a list of servers
+func (s *ServerService) List(context context.Context) (*[]Server, error) {
+	data := struct {
+		Response struct {
+			Servers []Server
+		}
+	}{}
+	err := s.client.get(context, "server/list", &data)
+	return &data.Response.Servers, err
+}
+
+// Start turns on a server
+func (s *ServerService) Start(context context.Context, serverID string) error {
+	return s.client.post(context, "server/start", nil, map[string]string{"serverid": serverID})
+}
+
+// Stop turns off a server
+func (s *ServerService) Stop(context context.Context, serverID string, params StopServerParams) error {
+	return s.client.post(context, "server/stop", nil, struct {
+		StopServerParams
+		ServerID string `json:"serverid"`
+	}{params, serverID})
+}
+
+func generateHostname() string {
+	adjectives := []string{"autumn", "hidden", "bitter", "misty", "silent",
+		"empty", "dry", "dark", "summer", "icy", "delicate", "quiet", "white",
+		"cool", "spring", "winter", "patient", "twilight", "dawn", "crimson",
+		"wispy", "weathered", "blue", "billowing", "broken", "cold", "damp",
+		"falling", "frosty", "green", "long", "late", "lingering", "bold", "little",
+		"morning", "muddy", "old", "red", "rough", "still", "small", "sparkling",
+		"throbbing", "shy", "wandering", "withered", "wild", "black", "young",
+		"holy", "solitary", "fragrant", "aged", "snowy", "proud", "floral",
+		"restless", "divine", "polished", "ancient", "purple", "lively", "nameless"}
+	nouns := []string{"waterfall", "river", "breeze", "moon", "rain", "wind",
+		"sea", "morning", "snow", "lake", "sunset", "pine", "shadow", "leaf",
+		"dawn", "glitter", "forest", "hill", "cloud", "meadow", "sun", "glade",
+		"bird", "brook", "butterfly", "trout", "bush", "dew", "dust", "field",
+		"fire", "flower", "firefly", "feather", "grass", "haze", "mountain",
+		"night", "pond", "darkness", "snowflake", "silence", "sound", "sky",
+		"shape", "surf", "thunder", "violet", "water", "wildflower", "wave",
+		"water", "resonance", "sun", "wood", "dream", "cherry", "tree", "fog",
+		"frost", "voice", "paper", "frog", "smoke", "star"}
+
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	sections := []string{
+		adjectives[rand.Intn(len(adjectives))],
+		nouns[rand.Intn(len(nouns))],
+		strconv.Itoa(100 + rand.Intn(899)),
+	}
+
+	return strings.Join(sections, "-")
+}

--- a/v2/servers.go
+++ b/v2/servers.go
@@ -33,18 +33,23 @@ type User struct {
 
 // ServerDetails is a more complete representation of a server
 type ServerDetails struct {
-	CPU         int    `json:"cpucores"`
-	Bandwidth   int    `json:"bandwidth"`
-	DataCenter  string `json:"datacenter"`
-	Description string `json:"description"`
-	Hostname    string `json:"hostname"`
-	ID          string `json:"serverid"`
-	IPList      []IP   `json:"iplist"`
-	Platform    string `json:"platform"`
-	Memory      int    `json:"memorysize"`
-	State       string `json:"state"`
-	Storage     int    `json:"disksize"`
-	Template    string `json:"templatename"`
+	CPU         int          `json:"cpucores"`
+	Bandwidth   int          `json:"bandwidth"`
+	DataCenter  string       `json:"datacenter"`
+	Description string       `json:"description"`
+	Hostname    string       `json:"hostname"`
+	ID          string       `json:"serverid"`
+	IPList      []ServerIP   `json:"iplist"`
+	Platform    string       `json:"platform"`
+	Memory      int          `json:"memorysize"`
+	State       string       `json:"state"`
+	Storage     int          `json:"disksize"`
+	Template    string       `json:"templatename"`
+}
+
+type ServerIP struct {
+	Address         string   `json:"ipaddress"`
+	Version         int      `json:"version,omitempty"`
 }
 
 // IsLocked returns true if the server is currently locked, false otherwise

--- a/v2/servers.go
+++ b/v2/servers.go
@@ -26,30 +26,30 @@ type Server struct {
 
 // User represents a system user when creating servers (currently supported in KVM)
 type User struct {
-	Username     string   `json:"username"`
-	PublicKeys   []string `json:"sshkeys,omitempty"`
-	Password     string   `json:"password,omitempty"`
+	Username   string   `json:"username"`
+	PublicKeys []string `json:"sshkeys,omitempty"`
+	Password   string   `json:"password,omitempty"`
 }
 
 // ServerDetails is a more complete representation of a server
 type ServerDetails struct {
-	CPU         int          `json:"cpucores"`
-	Bandwidth   int          `json:"bandwidth"`
-	DataCenter  string       `json:"datacenter"`
-	Description string       `json:"description"`
-	Hostname    string       `json:"hostname"`
-	ID          string       `json:"serverid"`
-	IPList      []ServerIP   `json:"iplist"`
-	Platform    string       `json:"platform"`
-	Memory      int          `json:"memorysize"`
-	State       string       `json:"state"`
-	Storage     int          `json:"disksize"`
-	Template    string       `json:"templatename"`
+	CPU         int        `json:"cpucores"`
+	Bandwidth   int        `json:"bandwidth"`
+	DataCenter  string     `json:"datacenter"`
+	Description string     `json:"description"`
+	Hostname    string     `json:"hostname"`
+	ID          string     `json:"serverid"`
+	IPList      []ServerIP `json:"iplist"`
+	Platform    string     `json:"platform"`
+	Memory      int        `json:"memorysize"`
+	State       string     `json:"state"`
+	Storage     int        `json:"disksize"`
+	Template    string     `json:"templatename"`
 }
 
 type ServerIP struct {
-	Address         string   `json:"ipaddress"`
-	Version         int      `json:"version,omitempty"`
+	Address string `json:"ipaddress"`
+	Version int    `json:"version,omitempty"`
 }
 
 // IsLocked returns true if the server is currently locked, false otherwise
@@ -114,7 +114,7 @@ func (p CreateServerParams) WithDefaults() CreateServerParams {
 // Existing parameters will not be overwritten.
 func (p CreateServerParams) WithUser(username string, publicKeys []string, password string) CreateServerParams {
 
-	p.Users = append(p.Users , User{
+	p.Users = append(p.Users, User{
 		username,
 		publicKeys,
 		password,

--- a/v2/servers_test.go
+++ b/v2/servers_test.go
@@ -60,22 +60,21 @@ func TestCreateServerParamsCustomWithDefaults(t *testing.T) {
 
 func TestCreateServerParamsWithUsers(t *testing.T) {
 	params := CreateServerParams{
-		Bandwidth: 100,
-		CPU: 2,
+		Bandwidth:  100,
+		CPU:        2,
 		DataCenter: "Falkenberg",
-		IPv4: "any",
-		IPv6: "any",
-		Memory: 2048,
-		Storage: 20,
-		Platform: "KVM",
-		Template: "ubuntu-18-04",
-		Hostname: "kvmXXXXXXX",
-
+		IPv4:       "any",
+		IPv6:       "any",
+		Memory:     2048,
+		Storage:    20,
+		Platform:   "KVM",
+		Template:   "ubuntu-18-04",
+		Hostname:   "kvmXXXXXXX",
 	}.WithUser("glesys", []string{"ssh-rsa"}, "password")
 
 	users := []User{{"glesys",
-		 []string{"ssh-rsa"},
-		 "password",
+		[]string{"ssh-rsa"},
+		"password",
 	}}
 
 	assert.Equal(t, 100, params.Bandwidth, "Bandwidth has correct default value")

--- a/v2/servers_test.go
+++ b/v2/servers_test.go
@@ -1,0 +1,178 @@
+package glesys
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServerDetailsIsLocked(t *testing.T) {
+	serverDetails := ServerDetails{}
+
+	assert.Equal(t, false, serverDetails.IsLocked(), "should not be locked")
+
+	serverDetails.State = "locked"
+	assert.Equal(t, true, serverDetails.IsLocked(), "should be locked")
+}
+
+func TestServerDetailsIsRunning(t *testing.T) {
+	serverDetails := ServerDetails{}
+
+	assert.Equal(t, false, serverDetails.IsRunning(), "should not be running")
+
+	serverDetails.State = "running"
+	assert.Equal(t, true, serverDetails.IsRunning(), "should be running")
+}
+
+func TestCreateServerParamsWithDefaults(t *testing.T) {
+	params := CreateServerParams{}.WithDefaults()
+
+	assert.Equal(t, 100, params.Bandwidth, "Bandwidth has correct default value")
+	assert.Equal(t, 2, params.CPU, "CPU has correct default value")
+	assert.Equal(t, "Falkenberg", params.DataCenter, "DataCenter has correct default value")
+	assert.Equal(t, "any", params.IPv4, "IPv4 has correct default value")
+	assert.Equal(t, "any", params.IPv6, "IPv6 has correct default value")
+	assert.Equal(t, 2048, params.Memory, "Memory has correct default value")
+	assert.Equal(t, "OpenVZ", params.Platform, "Platform has correct default value")
+	assert.Equal(t, 50, params.Storage, "Storage has correct default value")
+	assert.Equal(t, "Debian 8 64-bit", params.Template, "Template has correct default value")
+
+	assert.NotEmpty(t, params.Hostname, "Hostname has a default value")
+}
+
+func TestCreateServerParamsCustomWithDefaults(t *testing.T) {
+	params := CreateServerParams{
+		DataCenter: "Stockholm",
+		Memory:     4096,
+	}.WithDefaults()
+
+	assert.Equal(t, 100, params.Bandwidth, "Bandwidth has correct default value")
+	assert.Equal(t, 2, params.CPU, "CPU has correct default value")
+	assert.Equal(t, "Stockholm", params.DataCenter, "DataCenter has correct custom value")
+	assert.Equal(t, "any", params.IPv4, "IPv4 has correct default value")
+	assert.Equal(t, "any", params.IPv6, "IPv6 has correct default value")
+	assert.Equal(t, 4096, params.Memory, "Memory has correct custom value")
+	assert.Equal(t, "OpenVZ", params.Platform, "Platform has correct default value")
+	assert.Equal(t, 50, params.Storage, "Storage has correct default value")
+	assert.Equal(t, "Debian 8 64-bit", params.Template, "Template has correct default value")
+}
+
+func TestCreateServerParamsWithUsers(t *testing.T) {
+	params := CreateServerParams{
+		Bandwidth: 100,
+		CPU: 2,
+		DataCenter: "Falkenberg",
+		IPv4: "any",
+		IPv6: "any",
+		Memory: 2048,
+		Storage: 20,
+		Platform: "KVM",
+		Template: "ubuntu-18-04",
+		Hostname: "kvmXXXXXXX",
+
+	}.WithUser("glesys", []string{"ssh-rsa"}, "password")
+
+	users := []User{{"glesys",
+		 []string{"ssh-rsa"},
+		 "password",
+	}}
+
+	assert.Equal(t, 100, params.Bandwidth, "Bandwidth has correct default value")
+	assert.Equal(t, 2, params.CPU, "CPU has correct default value")
+	assert.Equal(t, "Falkenberg", params.DataCenter, "DataCenter has correct default value")
+	assert.Equal(t, "any", params.IPv4, "IPv4 has correct default value")
+	assert.Equal(t, "any", params.IPv6, "IPv6 has correct default value")
+	assert.Equal(t, 2048, params.Memory, "Memory has correct default value")
+	assert.Equal(t, "KVM", params.Platform, "Platform has correct default value")
+	assert.Equal(t, 20, params.Storage, "Storage has correct default value")
+	assert.Equal(t, "ubuntu-18-04", params.Template, "Template has correct default value")
+	assert.Equal(t, users, params.Users, "Users has correct default value")
+
+	assert.NotEmpty(t, params.Hostname, "Hostname has a default value")
+}
+
+func TestServersCreate(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "server": { "serverid": "vz12345" } } }`}
+	s := ServerService{client: c}
+
+	server, _ := s.Create(context.Background(), CreateServerParams{})
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "server/create", c.lastPath, "path used is correct")
+	assert.Equal(t, "vz12345", server.ID, "server ID is correct")
+}
+
+func TestServersDestroy(t *testing.T) {
+	c := &mockClient{}
+	s := ServerService{client: c}
+
+	s.Destroy(context.Background(), "vz123456", DestroyServerParams{})
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "server/destroy", c.lastPath, "path used is correct")
+}
+
+func TestServersDetails(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "server": { "hostname": "my-server-123",
+		"bandwidth": 100,
+		"description": "MyServer",
+		"templatename": "Debian 8 64-bit"
+		} } }`}
+	s := ServerService{client: c}
+
+	server, _ := s.Details(context.Background(), "vz123456")
+
+	assert.Equal(t, "GET", c.lastMethod, "method used is correct")
+	assert.Equal(t, "server/details/serverid/vz123456/includestate/yes", c.lastPath, "path used is correct")
+	assert.Equal(t, "my-server-123", server.Hostname, "server Hostname is correct")
+	assert.Equal(t, 100, server.Bandwidth, "server bandwidth is correct")
+	assert.Equal(t, "MyServer", server.Description, "server Description is correct")
+	assert.Equal(t, "Debian 8 64-bit", server.Template, "server Template is correct")
+}
+
+func TestServersEdit(t *testing.T) {
+	c := &mockClient{}
+	s := ServerService{client: c}
+
+	s.Edit(context.Background(), "vz123456", EditServerParams{})
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "server/edit", c.lastPath, "path used is correct")
+}
+
+func TestServersList(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "servers": [{ "serverid": "vz12345" }] } }`}
+	s := ServerService{client: c}
+
+	servers, _ := s.List(context.Background())
+
+	assert.Equal(t, "GET", c.lastMethod, "method used is correct")
+	assert.Equal(t, "server/list", c.lastPath, "path used is correct")
+	assert.Equal(t, "vz12345", (*servers)[0].ID, "one server was returned")
+}
+
+func TestServersStart(t *testing.T) {
+	c := &mockClient{}
+	s := ServerService{client: c}
+
+	s.Start(context.Background(), "vz123456")
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "server/start", c.lastPath, "path used is correct")
+}
+
+func TestServersStop(t *testing.T) {
+	c := &mockClient{}
+	s := ServerService{client: c}
+
+	s.Stop(context.Background(), "vz123456", StopServerParams{})
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "server/stop", c.lastPath, "path used is correct")
+}
+
+func TestGenerateHostnameReturnsAHostnameInTheCorrectFormat(t *testing.T) {
+	hostname := generateHostname()
+	assert.Regexp(t, "^\\w+-\\w+-\\d{3}$", hostname, "Hostname is dasherized and contains two words followed by a number")
+}

--- a/v2/test.go
+++ b/v2/test.go
@@ -1,0 +1,24 @@
+package glesys
+
+import (
+	"context"
+	"encoding/json"
+)
+
+type mockClient struct {
+	body       string
+	lastPath   string
+	lastMethod string
+}
+
+func (c *mockClient) get(ctx context.Context, path string, v interface{}) error {
+	c.lastPath = path
+	c.lastMethod = "GET"
+	return json.Unmarshal([]byte(c.body), v)
+}
+
+func (c *mockClient) post(ctx context.Context, path string, v interface{}, params interface{}) error {
+	c.lastPath = path
+	c.lastMethod = "POST"
+	return json.Unmarshal([]byte(c.body), v)
+}


### PR DESCRIPTION
Go modules with version higher then v1 need to place the source code in directory with version major number. Ex /v2 
See more: https://blog.golang.org/v2-go-modules

ServerDetails was referring to IP struct that expected same response as for /ip/details but that's not true for /server/details