### PR TITLE
Update DNSDomains CreateRecords type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.4.2] - 2020-05-07
+- Use string type for CreateRecords. - @norrland
+- Properly comment ServerIP struct - @norrland
+### Changed
 ## [2.4.1] - 2020-04-30
 ### Changed
 - v2 dir for proper Go module versioning support. - @larsdunemark

--- a/v2/dnsdomains.go
+++ b/v2/dnsdomains.go
@@ -39,7 +39,7 @@ type DNSDomainPrice struct {
 // use CreateRecords = false to not create additional records.
 type AddDNSDomainParams struct {
 	Name              string `json:"domainname"`
-	CreateRecords     bool   `json:"createrecords,omitempty"`
+	CreateRecords     string `json:"createrecords,omitempty"`
 	Expire            int    `json:"expire,omitempty"`
 	Minimum           int    `json:"minimum,omitempty"`
 	PrimaryNameServer string `json:"primarynameserver,omitempty"`

--- a/v2/dnsdomains_test.go
+++ b/v2/dnsdomains_test.go
@@ -15,7 +15,7 @@ func TestDnsDomainsAdd(t *testing.T) {
 
 	params := AddDNSDomainParams{
 		Name:          "example.com",
-		CreateRecords: false,
+		CreateRecords: "no",
 	}
 
 	domain, _ := d.AddDNSDomain(context.Background(), params)


### PR DESCRIPTION
Use string values when setting the CreateRecords option AddDNSDomainParams.