### PR TITLE
travis: build only on golang 1.11 and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: go
 
 go:
-  - 1.10.x
   - 1.11.x
   - 1.12.x
   - 1.13.x
+  - 1.14.x
+  - 1.15.x
+
+env:
+  - GO111MODULE=on
 
 install:
   - go get -d -t ./...

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the official client library for interacting with the
 
 ## Requirements
 
-- Go 1.7 or higher (relies on [context](https://golang.org/pkg/context/))
+- Go 1.11 or higher. Required for modules support, older versions may still build but are not guaranteed to work.
 
 ## Getting Started
 


### PR DESCRIPTION
Remove older versions of golang that does not have the
module support.

Fixes #29 