### PR TITLE
Servers: begin deprecation of ServerDetails.State

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
+## [3.1.0] - Unreleased
+### Changed
+- **BREAKING:** - server IsRunning() and IsLocked() functions deprecated.
+- New fields in ServerDetails: IsRunning & IsLocked to match new fields returned
+  by API.
+
 ## [3.0.0] - 2021-11-11
 ### Changed
 - **BREAKING:** - Cost and Amount changed from int to float64. - @norrland

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
-## [3.1.0] - Unreleased
+## [4.0.0] - Unreleased
 ### Changed
 - **BREAKING:** - server IsRunning() and IsLocked() functions deprecated.
 - New fields in ServerDetails: IsRunning & IsLocked to match new fields returned

--- a/client.go
+++ b/client.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 )
 
-const version = "3.0.0"
+const version = "3.1.0"
 
 type httpClientInterface interface {
 	Do(*http.Request) (*http.Response, error)

--- a/client.go
+++ b/client.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 )
 
-const version = "3.1.0"
+const version = "4.0.0"
 
 type httpClientInterface interface {
 	Do(*http.Request) (*http.Response, error)

--- a/client_test.go
+++ b/client_test.go
@@ -33,7 +33,7 @@ func TestRequestHasCorrectHeaders(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, "application/json", request.Header.Get("Content-Type"), "header Content-Type is correct")
-	assert.Equal(t, "test-application/0.0.1 glesys-go/3.0.0", request.Header.Get("User-Agent"), "header User-Agent is correct")
+	assert.Equal(t, "test-application/0.0.1 glesys-go/3.1.0", request.Header.Get("User-Agent"), "header User-Agent is correct")
 
 	assert.NotEmpty(t, request.Header.Get("Authorization"), "header Authorization is not empty")
 }
@@ -43,7 +43,7 @@ func TestEmptyUserAgent(t *testing.T) {
 
 	request, err := client.newRequest(context.Background(), "GET", "/", nil)
 	assert.NoError(t, err)
-	assert.Equal(t, "glesys-go/3.0.0", request.Header.Get("User-Agent"), "header User-Agent is correct")
+	assert.Equal(t, "glesys-go/3.1.0", request.Header.Get("User-Agent"), "header User-Agent is correct")
 }
 
 func TestGetResponseErrorMessage(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -33,7 +33,7 @@ func TestRequestHasCorrectHeaders(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, "application/json", request.Header.Get("Content-Type"), "header Content-Type is correct")
-	assert.Equal(t, "test-application/0.0.1 glesys-go/3.1.0", request.Header.Get("User-Agent"), "header User-Agent is correct")
+	assert.Equal(t, "test-application/0.0.1 glesys-go/4.0.0", request.Header.Get("User-Agent"), "header User-Agent is correct")
 
 	assert.NotEmpty(t, request.Header.Get("Authorization"), "header Authorization is not empty")
 }
@@ -43,7 +43,7 @@ func TestEmptyUserAgent(t *testing.T) {
 
 	request, err := client.newRequest(context.Background(), "GET", "/", nil)
 	assert.NoError(t, err)
-	assert.Equal(t, "glesys-go/3.1.0", request.Header.Get("User-Agent"), "header User-Agent is correct")
+	assert.Equal(t, "glesys-go/4.0.0", request.Header.Get("User-Agent"), "header User-Agent is correct")
 }
 
 func TestGetResponseErrorMessage(t *testing.T) {

--- a/doc_test.go
+++ b/doc_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	glesys "github.com/glesys/glesys-go/v3"
+	glesys "github.com/glesys/glesys-go/v4"
 )
 
 func ExampleEmailDomainService_Overview() {

--- a/servers.go
+++ b/servers.go
@@ -41,6 +41,8 @@ type ServerDetails struct {
 	ID              string                `json:"serverid"`
 	InitialTemplate ServerTemplateDetails `json:"initialtemplate,omitempty"`
 	IPList          []ServerIP            `json:"iplist"`
+	IsRunning       bool                  `json:"isrunning"`
+	IsLocked        bool                  `json:"islocked"`
 	Platform        string                `json:"platform"`
 	Memory          int                   `json:"memorysize"`
 	State           string                `json:"state"`
@@ -59,16 +61,6 @@ type ServerTemplateDetails struct {
 type ServerIP struct {
 	Address string `json:"ipaddress"`
 	Version int    `json:"version,omitempty"`
-}
-
-// IsLocked returns true if the server is currently locked, false otherwise
-func (sd *ServerDetails) IsLocked() bool {
-	return sd.State == "locked"
-}
-
-// IsRunning returns true if the server is currently running, false otherwise
-func (sd *ServerDetails) IsRunning() bool {
-	return sd.State == "running"
 }
 
 // CreateServerParams is used when creating a new server

--- a/servers_test.go
+++ b/servers_test.go
@@ -10,19 +10,19 @@ import (
 func TestServerDetailsIsLocked(t *testing.T) {
 	serverDetails := ServerDetails{}
 
-	assert.Equal(t, false, serverDetails.IsLocked(), "should not be locked")
+	assert.Equal(t, false, serverDetails.IsLocked, "should not be locked")
 
-	serverDetails.State = "locked"
-	assert.Equal(t, true, serverDetails.IsLocked(), "should be locked")
+	serverDetails.IsLocked = true
+	assert.Equal(t, true, serverDetails.IsLocked, "should be locked")
 }
 
 func TestServerDetailsIsRunning(t *testing.T) {
 	serverDetails := ServerDetails{}
 
-	assert.Equal(t, false, serverDetails.IsRunning(), "should not be running")
+	assert.Equal(t, false, serverDetails.IsRunning, "should not be running")
 
-	serverDetails.State = "running"
-	assert.Equal(t, true, serverDetails.IsRunning(), "should be running")
+	serverDetails.IsRunning = true
+	assert.Equal(t, true, serverDetails.IsRunning, "should be running")
 }
 
 func TestCreateServerParamsWithDefaults(t *testing.T) {


### PR DESCRIPTION
Use IsLocked and IsRunning attributes in ServerDetails to get a more detailed state of the server rather than relying on the State attribute.

This will deprecate the IsRunning() and IsLocked() functions. Use the attributes directly instead.