### PR TITLE
DnsDomains Register/Transfer parameter OrganizationNumber deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   Use 'UsedInMiB' and 'QuotaInGiB'
 - **BREAKING:** - LoadBalancers 'AddtoBlacklist' 'RemoveFromBlacklist' deprecated.
   Use 'AddToBlocklist' and 'RemoveFromBlocklist' instead.
+- **BREAKING:** - DNSDomains OrganizationNumber deprecated. Use 'NationalID'
+  instead.
 ### Added
 - Implement Server Templates endpoint.
 

--- a/dnsdomains.go
+++ b/dnsdomains.go
@@ -73,17 +73,17 @@ type RegistrarInfo struct {
 
 // RegisterDNSDomainParams - parameters used when registering a domain
 type RegisterDNSDomainParams struct {
-	Name               string `json:"domainname"`
-	Address            string `json:"address"`
-	City               string `json:"city"`
-	Country            string `json:"country"`
-	Email              string `json:"email"`
-	Firstname          string `json:"firstname"`
-	Lastname           string `json:"lastname"`
-	OrganizationNumber int    `json:"organizationnumber"`
-	Organization       string `json:"organization"`
-	PhoneNumber        string `json:"phonenumber"`
-	ZipCode            string `json:"zipcode"`
+	Name         string `json:"domainname"`
+	Address      string `json:"address"`
+	City         string `json:"city"`
+	Country      string `json:"country"`
+	Email        string `json:"email"`
+	Firstname    string `json:"firstname"`
+	Lastname     string `json:"lastname"`
+	NationalID   int    `json:"nationalid"`
+	Organization string `json:"organization"`
+	PhoneNumber  string `json:"phonenumber"`
+	ZipCode      string `json:"zipcode"`
 
 	FaxNumber string `json:"fax,omitempty"`
 	NumYears  int    `json:"numyears,omitempty"`

--- a/dnsdomains_test.go
+++ b/dnsdomains_test.go
@@ -125,16 +125,16 @@ func TestDnsDomainsRegister(t *testing.T) {
 
 	d := DNSDomainService{client: c}
 	params := RegisterDNSDomainParams{
-		Name:               "example.com",
-		Firstname:          "Alice",
-		Lastname:           "Smith",
-		Email:              "alice@example.com",
-		Address:            "Badhusvägen 45",
-		City:               "Falkenberg",
-		ZipCode:            "31132",
-		Country:            "SE",
-		Organization:       "Internetz",
-		OrganizationNumber: 13337,
+		Name:         "example.com",
+		Firstname:    "Alice",
+		Lastname:     "Smith",
+		Email:        "alice@example.com",
+		Address:      "Badhusvägen 45",
+		City:         "Falkenberg",
+		ZipCode:      "31132",
+		Country:      "SE",
+		Organization: "Internetz",
+		NationalID:   13337,
 	}
 
 	domain, _ := d.Register(context.Background(), params)
@@ -190,16 +190,16 @@ func TestDnsDomainsTransfer(t *testing.T) {
 
 	d := DNSDomainService{client: c}
 	params := RegisterDNSDomainParams{
-		Name:               "example.com",
-		Firstname:          "Alice",
-		Lastname:           "Smith",
-		Email:              "alice@example.com",
-		Address:            "Badhusvägen 45",
-		City:               "Falkenberg",
-		ZipCode:            "31132",
-		Country:            "SE",
-		Organization:       "Internetz",
-		OrganizationNumber: 13337,
+		Name:         "example.com",
+		Firstname:    "Alice",
+		Lastname:     "Smith",
+		Email:        "alice@example.com",
+		Address:      "Badhusvägen 45",
+		City:         "Falkenberg",
+		ZipCode:      "31132",
+		Country:      "SE",
+		Organization: "Internetz",
+		NationalID:   13337,
 	}
 
 	domain, _ := d.Transfer(context.Background(), params)


### PR DESCRIPTION
The field OrganizationNumber has been deprecated in favor of NationalID.

Fixes #58