### PR TITLE
Implement Servers PreviewCloudConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   instead.
 ### Added
 - Implement Server Templates endpoint.
+- Implement Server PreviewCloudConfig endpoint.
 
 ## [4.0.1] - 2022-09-20
 ### Change

--- a/doc_test.go
+++ b/doc_test.go
@@ -462,6 +462,24 @@ func ExampleServerService_Templates() {
 	}
 }
 
+func ExampleServerService_PreviewCloudConfig() {
+	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
+
+	cloudconfig := "## template: glesys\n#cloud-config\n{{>users}}"
+	users := []glesys.User{}
+	users = append(users, glesys.User{
+		Username:   "bob",
+		Password:   "hunter2!",
+		PublicKeys: []string{"ssh-ed25519 AAAAC3NKEY bob@bob-machine"},
+	})
+
+	preview, _ := client.Servers.PreviewCloudConfig(context.Background(), glesys.PreviewCloudConfigParams{
+		CloudConfig: cloudconfig,
+		Users:       users,
+	})
+
+	fmt.Println(preview.Context.Users[0].Username)
+}
 func ExampleObjectStorageService_CreateInstance() {
 	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
 

--- a/servers.go
+++ b/servers.go
@@ -167,6 +167,24 @@ type StopServerParams struct {
 	Type string `json:"type"`
 }
 
+// PreviewCloudConfigParams
+type PreviewCloudConfigParams struct {
+	CloudConfig string `json:"cloudconfig"`
+	Users       []User `json:"users,omitempty"`
+}
+
+// PreviewContext
+type PreviewContext struct {
+	Params []string `json:"params,omitempty"`
+	Users  []User   `json:"users"`
+}
+
+// CloudConfigPreview is returned when calling PreviewCloudConfig
+type CloudConfigPreview struct {
+	Preview string         `json:"preview"`
+	Context PreviewContext `json:"context"`
+}
+
 // Create creates a new server
 func (s *ServerService) Create(context context.Context, params CreateServerParams) (*ServerDetails, error) {
 	data := struct {
@@ -220,6 +238,19 @@ func (s *ServerService) List(context context.Context) (*[]Server, error) {
 	}{}
 	err := s.client.get(context, "server/list", &data)
 	return &data.Response.Servers, err
+}
+
+// PreviewCloudConfig preview a cloud config mustache template.
+func (s *ServerService) PreviewCloudConfig(context context.Context, params PreviewCloudConfigParams) (*CloudConfigPreview, error) {
+	data := struct {
+		Response struct {
+			Cloudconfig CloudConfigPreview
+		}
+	}{}
+	err := s.client.post(context, "server/previewcloudconfig", &data, struct {
+		PreviewCloudConfigParams
+	}{params})
+	return &data.Response.Cloudconfig, err
 }
 
 // Templates lists all supported templates per platform

--- a/servers_test.go
+++ b/servers_test.go
@@ -102,6 +102,34 @@ func TestServersCreate(t *testing.T) {
 	assert.Equal(t, "vz12345", server.ID, "server ID is correct")
 }
 
+func TestServersPreviewCloudConfig(t *testing.T) {
+	c := &mockClient{body: `{"response":{
+			"cloudconfig":{
+				"preview": "#cloud-config\nusers:\n    -\n        name: bob\n        shell: /bin/bash\n        lock_passwd: false\n        sudo: 'ALL=(ALL) PASSWD:ALL'\n        passwd: $6$ecb46c3c2a73263f$wYkIrbHQzZ0zZvsb7PxdhIbskjOA4Ti5NnDe7EBBP.1SDAfborckfDcuYsqDmdgbGMFJgBzQMjXgJ4qHbLV5s.\n        ssh_authorized_keys: ['ssh-ed25519 AAAAKEY bob@bob-machine']\nssh_pwauth: false\nchpasswd:\n    expire: false\n",
+			    "context": {"params": [],
+							"users": [{"username": "bob", "password": "hunter333", "sshKeys": ["ssh-ed25519 AAAAKEY bob@bob-machine"]}]
+						   }
+			}}}`}
+	s := ServerService{client: c}
+
+	users := []User{}
+	users = append(users, User{
+		Username:   "bob",
+		Password:   "hunter333",
+		PublicKeys: []string{"ssh-ed25519 AAAAKEY bob@bob-machine"},
+	})
+	params := PreviewCloudConfigParams{
+		CloudConfig: "## template: glesys\n#cloud-config\n{{>users}}\n",
+		Users:       users,
+	}
+
+	preview, _ := s.PreviewCloudConfig(context.Background(), params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "server/previewcloudconfig", c.lastPath, "path used is correct")
+	assert.Equal(t, "bob", preview.Context.Users[0].Username, "Preview contains user")
+}
+
 func TestServersDestroy(t *testing.T) {
 	c := &mockClient{}
 	s := ServerService{client: c}


### PR DESCRIPTION
Previewa cloud config mustache template with:

```
client := glesys.NewClient("CL12345","TOKEN","myuseragent")

users := []glesys.User{}
users = append(users, glesys.User{
    Username:   "bob",
    Password:   "hunter2!",
    PublicKeys: []string{"ssh-ed25519 AAAAKEY bob@bob-machine"},
})

preview, err := Servers.PreviewCloudConfig(ctx, PreviewCloudConfigParams{
    CloudConfig: "## template: glesys\n#cloud-config\n{{>users}}",
    Users: users,
}

fmt.Printf("preview %#v\n", preview)
```