### PR TITLE
Remove deprecated ioutil calls

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -150,7 +150,7 @@ func (c *Client) parseResponseBody(response *http.Response, v interface{}) error
 	}
 
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return err
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -20,7 +20,7 @@ type mockHTTPClient struct {
 func (c *mockHTTPClient) Do(request *http.Request) (*http.Response, error) {
 	response := http.Response{
 		StatusCode: c.statusCode,
-		Body:       ioutil.NopCloser(bytes.NewBufferString(c.body)),
+		Body:       io.NopCloser(bytes.NewBufferString(c.body)),
 	}
 	c.lastRequest = request
 	return &response, nil
@@ -51,7 +51,7 @@ func TestGetResponseErrorMessage(t *testing.T) {
 
 	json := `{ "response": {"status": { "code": 400, "text": "Unauthorized" } } }`
 	response := http.Response{
-		Body:       ioutil.NopCloser(bytes.NewBufferString(json)),
+		Body:       io.NopCloser(bytes.NewBufferString(json)),
 		StatusCode: 400,
 	}
 	err := client.handleResponseError(&response)


### PR DESCRIPTION
io/ioutils has been deprecated as of Go 1.16.

Fixes #71