### PR TITLE
Add parameters for IPs.Reserved()

### DIFF
--- a/doc_test.go
+++ b/doc_test.go
@@ -141,7 +141,7 @@ func ExampleIPService_Reserve() {
 func ExampleIPService_Reserved() {
 	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
 
-	ips, _ := client.IPs.Reserved(context.Background())
+	ips, _ := client.IPs.Reserved(context.Background(), glesys.ReservedIPsParams{})
 
 	for _, ip := range *ips {
 		fmt.Println(ip.Address)

--- a/ips.go
+++ b/ips.go
@@ -36,6 +36,14 @@ type AvailableIPsParams struct {
 	Version    int    `json:"ipversion"`
 }
 
+// ReservedIPsParams is used to filter results when listing reserved IP addresses
+type ReservedIPsParams struct {
+	DataCenter string `json:"datacenter,omitempty"`
+	Platform   string `json:"platform,omitempty"`
+	Version    int    `json:"ipversion,omitempty"`
+	Used       string `json:"used,omitempty"`
+}
+
 // IPCost is used to show cost details for a IP address
 type IPCost struct {
 	Amount     float64 `json:"amount"`
@@ -106,13 +114,13 @@ func (s *IPService) Reserve(context context.Context, ipAddress string) (*IP, err
 }
 
 // Reserved returns a list of reserved IP addresses
-func (s *IPService) Reserved(context context.Context) (*[]IP, error) {
+func (s *IPService) Reserved(context context.Context, params ReservedIPsParams) (*[]IP, error) {
 	data := struct {
 		Response struct {
 			IPList []IP
 		}
 	}{}
-	err := s.client.get(context, "ip/listown", &data)
+	err := s.client.post(context, "ip/listown", &data, params)
 	return &data.Response.IPList, err
 }
 

--- a/ips_test.go
+++ b/ips_test.go
@@ -65,16 +65,22 @@ func TestIPsDetails(t *testing.T) {
 }
 
 func TestIPsReserved(t *testing.T) {
-	c := &mockClient{body: `{ "response": { "iplist": [{ "ipaddress": "127.0.0.1"},
-		{ "ipaddress": "2001:db8::1"}] } }`}
+	c := &mockClient{body: `{ "response": { "iplist": [{ "ipaddress": "127.0.0.1", "datacenter": "Falkenberg" },
+		{ "ipaddress": "2001:db8::1", "datacenter": "Falkenberg" }] } }`}
 	s := IPService{client: c}
 
-	ips, _ := s.Reserved(context.Background())
+	params := ReservedIPsParams{
+		DataCenter: "Falkenberg",
+	}
 
-	assert.Equal(t, "GET", c.lastMethod, "method used is correct")
+	ips, _ := s.Reserved(context.Background(), params)
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
 	assert.Equal(t, "ip/listown", c.lastPath, "path used is correct")
 	assert.Equal(t, "127.0.0.1", (*ips)[0].Address, "one ip was returned")
 	assert.Equal(t, "2001:db8::1", (*ips)[1].Address, "one ip was returned")
+	assert.Equal(t, "Falkenberg", (*ips)[0].DataCenter, "correct DataCenter was returned")
+	assert.Equal(t, "Falkenberg", (*ips)[1].DataCenter, "correct DataCenter was returned")
 }
 
 func TestIPsReserve(t *testing.T) {


### PR DESCRIPTION
Support optional arguments for ip/listown endpoint.

Filter on:

IP version, datacenter, platform and used.

Fixes #81
