### PR TITLE
email pw

### DIFF
--- a/doc_test.go
+++ b/doc_test.go
@@ -37,7 +37,6 @@ func ExampleEmailDomainService_EditAccount() {
 	editaccount, _ := client.EmailDomains.EditAccount(context.Background(), "user@example.com", glesys.EditAccountParams{
 		AntiSpamLevel:      3,
 		AntiVirus:          "yes",
-		Password:           "SuperSecretPassword",
 		AutoRespond:        "yes",
 		AutoRespondMessage: "Your Automatic Response",
 		QuotaInGiB:         10,

--- a/emaildomains.go
+++ b/emaildomains.go
@@ -51,6 +51,7 @@ type OverviewParams struct {
 type EmailAccount struct {
 	EmailAccount         string `json:"emailaccount"`
 	DisplayName          string `json:"displayname"`
+	Password             string `json:"password,omitempty"`
 	QuotaInGiB           int    `json:"quotaingib"`
 	AntiSpamLevel        int    `json:"antispamlevel"`
 	AntiVirus            string `json:"antivirus"`

--- a/emaildomains.go
+++ b/emaildomains.go
@@ -304,3 +304,18 @@ func (em *EmailDomainService) Costs(context context.Context) (*EmailCosts, error
 
 	return &EmailCosts{Costs: data.Response.Costs, PriceList: data.Response.PriceList}, err
 }
+
+// ResetPassword requests a new password from the API for emailaccount
+func (em *EmailDomainService) ResetPassword(context context.Context, emailaccount string) (string, error) {
+	data := struct {
+		Response struct {
+			Password string
+		}
+	}{}
+
+	err := em.client.post(context, "email/resetpassword", &data, struct {
+		EmailAccount string `json:"emailaccount"`
+	}{emailaccount})
+
+	return data.Response.Password, err
+}

--- a/emaildomains.go
+++ b/emaildomains.go
@@ -91,7 +91,6 @@ type ListEmailsParams struct {
 type EditAccountParams struct {
 	AntiSpamLevel      int    `json:"antispamlevel,omitempty"`
 	AntiVirus          string `json:"antivirus,omitempty"`
-	Password           string `json:"password,omitempty"`
 	AutoRespond        string `json:"autorespond,omitempty"`
 	AutoRespondMessage string `json:"autorespondmessage,omitempty"`
 	QuotaInGiB         int    `json:"quotaingib,omitempty"`

--- a/emaildomains_test.go
+++ b/emaildomains_test.go
@@ -248,3 +248,15 @@ func TestCosts(t *testing.T) {
 	assert.Equal(t, "accounts", costs.PriceList.Accounts.Unit, "pricelist.accounts.unit is correct")
 	assert.Equal(t, 50.00, costs.PriceList.Accounts.FreeAmount, "pricelist.accounts.freeamount is correct")
 }
+
+func TestResetPassword(t *testing.T) {
+	c := &mockClient{body: `{"response": {"password": "S3cr3t}pw!"}}`}
+
+	s := EmailDomainService{client: c}
+
+	newPw, _ := s.ResetPassword(context.Background(), "alice@example.com")
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "email/resetpassword", c.lastPath, "path used is correct")
+	assert.Equal(t, "S3cr3t}pw!", newPw, "password is correct")
+}


### PR DESCRIPTION
- Email EditAccount no longer takes password parameter
- EmailAccount contains a generated password on new accounts
- Implement email/resetpassword endpoint
