### PR TITLE
Implement User Login

### DIFF
--- a/client.go
+++ b/client.go
@@ -131,13 +131,13 @@ func (c *Client) do(request *http.Request, v interface{}) error {
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return c.handleResponseError(response)
+		return handleResponseError(response)
 	}
 
-	return c.parseResponseBody(response, v)
+	return parseResponseBody(response, v)
 }
 
-func (c *Client) handleResponseError(response *http.Response) error {
+func handleResponseError(response *http.Response) error {
 	data := struct {
 		Response struct {
 			Status struct {
@@ -146,7 +146,7 @@ func (c *Client) handleResponseError(response *http.Response) error {
 		} `json:"response"`
 	}{}
 
-	err := c.parseResponseBody(response, &data)
+	err := parseResponseBody(response, &data)
 	if err != nil {
 		return err
 	}
@@ -154,7 +154,7 @@ func (c *Client) handleResponseError(response *http.Response) error {
 	return fmt.Errorf("Request failed with HTTP error: %v (%v)", response.StatusCode, strings.TrimSpace(data.Response.Status.Text))
 }
 
-func (c *Client) parseResponseBody(response *http.Response, v interface{}) error {
+func parseResponseBody(response *http.Response, v interface{}) error {
 	if v == nil {
 		return nil
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -47,14 +47,12 @@ func TestEmptyUserAgent(t *testing.T) {
 }
 
 func TestGetResponseErrorMessage(t *testing.T) {
-	client := NewClient("project-id", "api-key", "test-application/0.0.1")
-
 	json := `{ "response": {"status": { "code": 400, "text": "Unauthorized" } } }`
 	response := http.Response{
 		Body:       io.NopCloser(bytes.NewBufferString(json)),
 		StatusCode: 400,
 	}
-	err := client.handleResponseError(&response)
+	err := handleResponseError(&response)
 	assert.Equal(t, "Request failed with HTTP error: 400 (Unauthorized)", err.Error(), "error message is correct")
 }
 

--- a/doc_test.go
+++ b/doc_test.go
@@ -7,6 +7,35 @@ import (
 	glesys "github.com/glesys/glesys-go/v7"
 )
 
+func ExampleUserService_DoOTPLogin() {
+	userAgent := "MyGleSYSClient 0.0.1"
+	login := glesys.NewLogin(userAgent)
+
+	loginDetails, err := login.Users.DoOTPLogin(
+		context.Background(),
+		"user@example.com",
+		"VerySecretPassword123",
+		"abc123-otpstring")
+
+	if err != nil {
+		fmt.Printf("Error logging in %s\n", err)
+	}
+
+	// Set the temporary key to the Login object
+	login.Username = loginDetails.Username
+	login.APIKey = loginDetails.APIKey
+
+	// Now you can run user specific calls to the api
+	// list projects for organization 12345
+	projects, err := login.Users.ListCustomerProjects(context.Background(), "12345")
+	if err != nil {
+		fmt.Printf("Error listing projects %s\n", err)
+	}
+	for _, project := range *projects {
+		fmt.Printf("Name: %s, ProjectID: %s\n", project.Name, project.Accountname)
+	}
+}
+
 func ExampleEmailDomainService_Overview() {
 	client := glesys.NewClient("CL12345", "your-api-key", "my-application/0.0.1")
 

--- a/login.go
+++ b/login.go
@@ -1,0 +1,230 @@
+package glesys
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Login is used for login data
+type Login struct {
+	BaseURL    *url.URL
+	UserAgent  string
+	httpClient httpClientInterface
+	Accounts   []Customer
+	Customers  []Customer
+	APIKey     string
+	Username   string
+
+	Users *UserService
+}
+
+type UserService struct {
+	client clientInterface
+}
+
+// LoginParams are used when calling user/login
+type LoginParams struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Otp      string `json:"otp,omitempty"`
+}
+
+// LoginDetailsResponse represents the result of a successful login.
+type LoginDetailsResponse struct {
+	Username  string     `json:"username"`
+	APIKey    string     `json:"apikey"`
+	Accounts  []Customer `json:"accounts,omitempty"`
+	Customers []Customer `json:"customers,omitempty"`
+}
+
+// Customer represents a customer/organization
+type Customer struct {
+	CustomerNumber string   `json:"customernumber"`
+	Description    string   `json:"description,omitempty"`
+	Roles          []string `json:"roles"`
+}
+
+// CustomerProject describes a project in GleSYS
+type CustomerProject struct {
+	Accountname    string `json:"accountname,omitempty"`
+	Name           string `json:"name,omitempty"`
+	Color          string `json:"color,omitempty"`
+	Currency       string `json:"currency,omitempty"`
+	Lockedreason   string `json:"lockedreason,omitempty"`
+	Access         string `json:"access,omitempty"`
+	Customernumber int    `json:"customernumber,omitempty"`
+}
+
+type UserOrganization struct {
+	ID                                int      `json:"id,omitempty"`
+	State                             string   `json:"state,omitempty"`
+	FeatureFlags                      []string `json:"featureflags,omitempty"`
+	Verification                      string   `json:"verification,omitempty"`
+	Type                              string   `json:"type,omitempty"`
+	IsOwner                           string   `json:"isowner,omitempty"`
+	ContactPerson                     string   `json:"contactperson,omitempty"`
+	NationalIdnumber                  string   `json:"nationalidnumber,omitempty"`
+	Name                              string   `json:"name,omitempty"`
+	Address                           string   `json:"address,omitempty"`
+	City                              string   `json:"city,omitempty"`
+	ZipCode                           string   `json:"zipcode,omitempty"`
+	Country                           string   `json:"country,omitempty"`
+	SeparateInvoiceAddress            string   `json:"separateinvoiceaddress,omitempty"`
+	InvoiceReference                  string   `json:"invoicereference,omitempty"`
+	InvoiceAddress                    string   `json:"invoiceaddress,omitempty"`
+	InvoiceCity                       string   `json:"invoicecity,omitempty"`
+	InvoiceZipcode                    string   `json:"invoicezipcode,omitempty"`
+	InvoiceCountry                    string   `json:"invoicecountry,omitempty"`
+	Email                             string   `json:"email,omitempty"`
+	Phonenumber                       string   `json:"phonenumber,omitempty"`
+	Invoicedeliverymethod             string   `json:"invoicedeliverymethod,omitempty"`
+	Billingemailoverrides             []string `json:"billingemailoverrides,omitempty"`
+	CurrentBillingEmails              []string `json:"currentbillingemails,omitempty"`
+	CanAccessBilling                  string   `json:"canaccessbilling,omitempty"`
+	ExpiredInvoices                   string   `json:"expiredinvoices,omitempty"`
+	UnpaidInvoices                    string   `json:"unpaidinvoices,omitempty"`
+	VatNumber                         string   `json:"vatnumber,omitempty"`
+	PaymentMethod                     string   `json:"paymentmethod,omitempty"`
+	PaymentCard                       int      `json:"paymentcard,omitempty"`
+	AllowedPaymentMethods             []string `json:"allowedpaymentmethods,omitempty"`
+	PaymentTermsnetdays               int      `json:"paymenttermsnetdays,omitempty"`
+	CanPayInvoicesManuallyUsingPaypal bool     `json:"canpayinvoicesmanuallyusingpaypal,omitempty"`
+	SlaCost                           int      `json:"slacost,omitempty"`
+	SlaLevel                          string   `json:"slalevel,omitempty"`
+	SlaPincode                        string   `json:"slapincode,omitempty"`
+	SlaPhonenumber                    string   `json:"slaphonenumber,omitempty"`
+}
+
+func (l *Login) do(request *http.Request, v interface{}) error {
+	response, err := l.httpClient.Do(request)
+	if err != nil {
+		return err
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return handleResponseError(response)
+	}
+
+	return parseResponseBody(response, v)
+}
+
+func (l *Login) get(ctx context.Context, path string, v interface{}) error {
+	request, err := l.newRequest(ctx, "GET", path, nil)
+	if err != nil {
+		return err
+	}
+	return l.do(request, v)
+}
+
+func (l *Login) post(ctx context.Context, path string, v interface{}, params interface{}) error {
+	request, err := l.newRequest(ctx, "POST", path, params)
+	if err != nil {
+		return err
+	}
+	return l.do(request, v)
+}
+
+func (l *Login) newRequest(ctx context.Context, method, path string, params interface{}) (*http.Request, error) {
+	u, err := url.Parse(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if l.BaseURL != nil {
+		u = l.BaseURL.ResolveReference(u)
+	}
+
+	buffer := new(bytes.Buffer)
+
+	if params != nil {
+		err = json.NewEncoder(buffer).Encode(params)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	request, err := http.NewRequestWithContext(ctx, method, u.String(), buffer)
+	if err != nil {
+		return nil, err
+	}
+
+	userAgent := strings.TrimSpace(fmt.Sprintf("%s glesys-go/%s", l.UserAgent, version))
+
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("User-Agent", userAgent)
+	request.SetBasicAuth(l.Username, l.APIKey)
+
+	return request, nil
+}
+
+// SetBaseURL can be used to set a custom BaseURL
+func (l *Login) SetBaseURL(bu string) error {
+	url, err := url.Parse(bu)
+	if err != nil {
+		return err
+	}
+	l.BaseURL = url
+	return nil
+}
+
+func NewLogin(useragent string) *Login {
+	BaseURL, _ := url.Parse("https://api.glesys.com")
+
+	l := &Login{
+		BaseURL:    BaseURL,
+		httpClient: http.DefaultClient,
+		UserAgent:  strings.TrimSpace(fmt.Sprintf("%s glesys-go/%s", useragent, version)),
+	}
+
+	l.Users = &UserService{client: l}
+
+	return l
+}
+
+func (l *UserService) DoOTPLogin(ctx context.Context, username, password, otp string) (*LoginDetailsResponse, error) {
+	params := &LoginParams{
+		username,
+		password,
+		otp,
+	}
+
+	data := struct {
+		Response struct {
+			Login LoginDetailsResponse
+		}
+	}{}
+	err := l.client.post(ctx, "user/login", &data, params)
+
+	return &data.Response.Login, err
+}
+
+func (l *UserService) ListOrganizations(ctx context.Context) (*[]UserOrganization, error) {
+	data := struct {
+		Response struct {
+			Organizations []UserOrganization
+		}
+	}{}
+
+	err := l.client.post(ctx, "user/listorganizations", &data, nil)
+
+	return &data.Response.Organizations, err
+}
+
+func (l *UserService) ListCustomerProjects(ctx context.Context, organizationNumber string) (*[]CustomerProject, error) {
+	data := struct {
+		Response struct {
+			Projects []CustomerProject
+		}
+	}{}
+
+	err := l.client.post(ctx, "customer/listprojects", &data, struct {
+		Organizationnumber string `json:"organizationnumber"`
+	}{organizationNumber})
+
+	return &data.Response.Projects, err
+}

--- a/login_test.go
+++ b/login_test.go
@@ -1,0 +1,104 @@
+package glesys
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUserLogin(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "login": { "username": "alice@example.com", "apikey": "abc-123-xyz" } } }`}
+	l := UserService{client: c}
+
+	loginDetails, error := l.DoOTPLogin(context.Background(), "alice@example.com", "SuperSecretPassword123", "cccc123xyzotpstring")
+	if error != nil {
+		fmt.Printf("Error on login %s", error)
+	}
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "user/login", c.lastPath, "path used is correct")
+	assert.Equal(t, "alice@example.com", loginDetails.Username, "Username is correct")
+	assert.Equal(t, "abc-123-xyz", loginDetails.APIKey, "APIKEY is correct")
+}
+
+func TestUserListOrganizations(t *testing.T) {
+	c := &mockClient{body: `{ "response": { "organizations": [{
+		"id": 1337,
+		"state": "active",
+		"featureflags": [],
+		"verification": "verified",
+		"type": "personal",
+		"isowner": "yes",
+		"contactperson": "",
+		"nationalidnumber": "123456",
+		"name": "Alice Smith",
+		"address": "Kanslistvägen 12",
+		"city": "Falkenberg",
+		"zipcode": "123 45",
+		"country": "SWEDEN",
+		"separateinvoiceaddress": "no",
+		"invoicereference": "test",
+		"invoiceaddress": "Kanslistvägen 12",
+		"invoicecity": "Falkenberg",
+		"invoicezipcode": "123 45",
+		"invoicecountry": "SWEDEN",
+		"email": "alice@example.com",
+		"phonenumber": "",
+		"invoicedeliverymethod": "email",
+		"billingemailoverrides": ["invoices@example.com"],
+		"currentbillingemails": ["invoices@example.com"],
+		"canaccessbilling": "yes",
+		"expiredinvoices": "no",
+		"unpaidinvoices": "no",
+		"vatnumber": "",
+		"paymentmethod": "invoice",
+		"paymentcard": "",
+		"allowedpaymentmethods": ["invoice", "card"],
+		"paymenttermsnetdays": 20,
+		"canpayinvoicesmanuallyusingpaypal": true,
+		"slacost": "",
+		"slalevel": "base",
+		"slapincode": "1234",
+		"slaphonenumber": "+461234567890"
+		}] } }`}
+
+	l := UserService{client: c}
+
+	orgs, _ := l.ListOrganizations(context.Background())
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "user/listorganizations", c.lastPath, "path used is correct")
+	assert.Equal(t, 1337, (*orgs)[0].ID, "Organization ID is correct")
+	assert.Equal(t, "personal", (*orgs)[0].Type, "Organization Type is correct")
+}
+
+func TestCustomerListProjects(t *testing.T) {
+	c := &mockClient{body: `{ "response": {
+	"projects": [{"accountname": "cl98765",
+	    "name": "prod",
+	    "color": "silver",
+	    "currency": "SEK",
+	    "lockedreason": "",
+	    "access": "full",
+	    "customernumber": 1337},
+	   {"accountname": "cl123456",
+	    "name": "dev",
+	    "color": "sandybrown",
+	    "currency": "SEK",
+	    "lockedreason": "",
+	    "access": "full",
+	    "customernumber": 1337}]}}
+	`}
+	l := UserService{client: c}
+
+	projects, _ := l.ListCustomerProjects(context.Background(), "1337")
+
+	assert.Equal(t, "POST", c.lastMethod, "method used is correct")
+	assert.Equal(t, "customer/listprojects", c.lastPath, "path used is correct")
+	assert.Equal(t, "prod", (*projects)[0].Name, "project name is correct")
+	assert.Equal(t, "dev", (*projects)[1].Name, "project name is correct")
+	assert.Equal(t, "silver", (*projects)[0].Color, "project color is correct")
+	assert.Equal(t, 1337, (*projects)[0].Customernumber, "project customernumber is correct")
+}


### PR DESCRIPTION
Make it possible to do user logins against the API, with or without OTP.

Implement ListOrganizations and ListCustomerProjects.

The Login is very similar to Client in the most parts. But needs to do things a bit differently
since we do not have a valid api-key before the first request.

* Make HTTP `handleResponseError` and `parseResponseBody` not specific for `Client`.