### PR TITLE
Add Type attribute to ServerDisks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Implemented `server/listiso` and `server/mountiso` endpoints.
 ### Changed
 - Add `ISOFile` attribute in `ServerDetails`.
+- Add `Type` attribute for disk policy in `ServerDiskDetails`.
 
 ## [8.3.1] - 2024-09-19
 ### Changed

--- a/doc_test.go
+++ b/doc_test.go
@@ -684,6 +684,7 @@ func ExampleServerDisksService_Create() {
 		ServerID:  "wps123456",
 		SizeInGIB: 125,
 		Name:      "Extra disk",
+		Type:      "silver", // [gold|silver]
 	}
 
 	_, _ = client.ServerDisks.Create(context.Background(), params)
@@ -691,7 +692,7 @@ func ExampleServerDisksService_Create() {
 	server, _ := client.Servers.Details(context.Background(), "wps123456")
 
 	for _, disk := range server.AdditionalDisks {
-		fmt.Printf("Disk%d: %s - %d\n", disk.SCSIID, disk.Name, disk.SizeInGIB)
+		fmt.Printf("Disk%d: %s - %d - Type: %s\n", disk.SCSIID, disk.Name, disk.SizeInGIB, disk.Type)
 	}
 }
 

--- a/serverdisks.go
+++ b/serverdisks.go
@@ -12,6 +12,7 @@ type CreateServerDiskParams struct {
 	Name      string `json:"name"`
 	ServerID  string `json:"serverid"`
 	SizeInGIB int    `json:"sizeingib"`
+	Type      string `json:"type,omitempty"`
 }
 
 // ServerDiskDetails represents any extra disks for a server
@@ -20,6 +21,7 @@ type ServerDiskDetails struct {
 	Name      string `json:"name,omitempty"`
 	SizeInGIB int    `json:"sizeingib"`
 	SCSIID    int    `json:"scsiid"`
+	Type      string `json:"type"`
 }
 
 // ServerDiskReconfigureParams parameters for updating a ServerDisk

--- a/serverdisks_test.go
+++ b/serverdisks_test.go
@@ -11,7 +11,8 @@ func TestServerDisk_Create(t *testing.T) {
 	c := &mockClient{body: `{ "response": { "disk": { "id": "aaaaa-bbbbbb-cccccc",
 		"sizeingib": 200,
 		"name": "Diskett",
-		"scsiid": 1
+		"scsiid": 1,
+		"type": "gold"
 		}}}`}
 	s := ServerDisksService{client: c}
 
@@ -26,6 +27,7 @@ func TestServerDisk_Create(t *testing.T) {
 	assert.Equal(t, "serverdisk/create", c.lastPath, "correct path is used")
 	assert.Equal(t, 200, disk.SizeInGIB, "size is correct")
 	assert.Equal(t, "Diskett", disk.Name, "correct name variable")
+	assert.Equal(t, "gold", disk.Type, "correct type variable")
 }
 
 func TestServerDisk_UpdateName(t *testing.T) {


### PR DESCRIPTION
When creating new ServerDisks, use the Type attribute to set disk policy for the
additional disk.

Fixes #123 